### PR TITLE
get auth config for image

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -16,6 +16,7 @@ import (
 	"net/url"
 	"os"
 	"reflect"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -414,6 +415,9 @@ type setupCloudConfig struct {
 
 func getAuthConfigForImage(image string) (docker.AuthConfiguration, error) {
 	var authConfig docker.AuthConfiguration
+	if !strings.Contains(image, "://") {
+		image = "//" + image
+	}
 	parsedURL, err := url.Parse(image)
 	if err != nil {
 		return authConfig, errors.New("local image, skipping auth config")


### PR DESCRIPTION
# Summary of this proposal

RunWithOptions needs to be explicit credentials for a private repository, in
this patch we load them from NewAuthConfigurationsFromDockerCfg()
and try to guess if the host part of the image (if any) has a valid AuthConfiguration,
if so, that's the one we use.


## Notes for the reviewer

<!-- Provide any notes that might be important for the (reviewer) of changes -->

## Issue(s) number(s)

https://github.com/calyptia/api/issues/9

## Checklist for submitter

- [X] My PR has a related issue/bug number.
- [ ] My PR provides tests
  - [ ] Integration tests are added/passes
  - [X] Unit tests are added/passes
  - [ ] End-to-end tests added/passes
  - [ ] Static code check added/passes
  - [ ] Linting on documentation added/passes
  - [ ] Does not affect code coverage stats
- [ ] My PR requires updating dependencies
- [ ] My PR has the documentation changes required.

## Checklist for reviewer

- [ ] The proposal fixes a bug/issue or implements a new feature that is well described.
- [ ] The proposal has sufficient test cases that covers the changes.
  - [ ] If changes an API, it does not break backwards compatibility (-1 major version).
- [ ] If integration is required, the proposal has integration tests.
- [ ] The proposal does not break coverage stats
- [ ] The proposal has the required documentation changes.

## Backport

<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backport to the current or earlier releases then please submit
a PR for that particular branch.
-->

- [ ] Backport to the latest stable release.