### PR TITLE
spec/client for config validation v2.

### DIFF
--- a/client/config_validator.go
+++ b/client/config_validator.go
@@ -14,3 +14,10 @@ func (c *Client) ValidateConfig(ctx context.Context, agentType types.AgentType, 
 	var out types.ValidatedConfig
 	return out, c.do(ctx, http.MethodPost, "/v1/config_validate/"+url.PathEscape(string(agentType)), payload, &out)
 }
+
+// ValidateConfigV2 validates that an already parsed fluentbit(only) config to check if semantically valid
+// To parse the raw agent config take a look at https://github.com/calyptia/fluent-bit-config-parser.
+func (c *Client) ValidateConfigV2(ctx context.Context, payload types.ValidatingConfig) (types.ValidatedConfigV2, error) {
+	var out types.ValidatedConfigV2
+	return out, c.do(ctx, http.MethodPost, "/v1/config_validate_v2", payload, &out)
+}

--- a/client/config_validator_test.go
+++ b/client/config_validator_test.go
@@ -39,3 +39,37 @@ func TestClient_ValidateConfig(t *testing.T) {
 	wantEqual(t, len(got.Errors.Filter), 0)
 	wantEqual(t, len(got.Errors.Output), 0)
 }
+
+func TestClient_ValidateConfigV2(t *testing.T) {
+	if testFluentbitConfigValidatorAPIKey == "" || testFluentdConfigValidatorAPIKey == "" {
+		t.Skip("TODO: setup fluentbit/d config validator API keys")
+	}
+
+	ctx := context.Background()
+	asUser := userClient(t)
+	withToken := withToken(t, asUser)
+
+	// Yes, config validation requires project token auth.
+	got, err := withToken.ValidateConfigV2(ctx, types.ValidatingConfig{
+		Configs: []types.ValidatingConfigEntry{
+			{
+				Command: "INPUT",
+				Name:    "tail",
+			},
+			{
+				Command: "FILTER",
+				Name:    "record_modifier",
+			},
+			{
+				Command: "OUTPUT",
+				Name:    "stdout",
+			},
+		},
+	})
+
+	wantEqual(t, err, nil)
+	wantEqual(t, len(got.Errors.Runtime), 0)
+	wantEqual(t, len(got.Errors.Input), 0)
+	wantEqual(t, len(got.Errors.Filter), 0)
+	wantEqual(t, len(got.Errors.Output), 0)
+}

--- a/spec/open-api.yml
+++ b/spec/open-api.yml
@@ -35,6 +35,7 @@ tags:
   - name: pipeline_secret
   - name: pipeline_port
   - name: config_validator
+  - name: config_validator_v2
   - name: metric
 components:
   securitySchemes:
@@ -1416,6 +1417,82 @@ components:
             - filter
       required:
         - errors
+
+    ConfigValidityV2Property:
+      type: object
+      description: Property of the validated configuration section
+      properties:
+        id:
+          description: ID of the configuration section
+          type: string
+        property:
+          description: property name
+          type: string
+        text:
+          description: property name, value
+          type: string
+        errors:
+          type: array
+          items:
+            type: string
+      required:
+        - id
+        - property
+        - text
+        - errors
+
+    ConfigValidityV2Runtime:
+      type: object
+      description: Runtime errors for the validated configuration.
+      properties:
+        errors:
+          type: array
+          items:
+            type: string
+        id:
+          description: Id of the configuration section
+          type: string
+      required:
+        - id
+        - errors
+
+    ValidatedConfigV2:
+      type: object
+      description: Validation V2 config response.
+      properties:
+        errors:
+          type: object
+          properties:
+            runtime:
+              type: array
+              additionalProperties:
+                $ref: "#/components/schemas/ConfigValidityV2Runtime"
+            input:
+              type: object
+              additionalProperties:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ConfigValidityV2Property"
+            output:
+              type: object
+              additionalProperties:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ConfigValidityV2Property"
+            filter:
+              type: object
+              additionalProperties:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ConfigValidityV2Property"
+          required:
+            - runtime
+            - input
+            - output
+            - filter
+      required:
+        - errors
+
 paths:
   /v1/verification_email:
     post:
@@ -2712,6 +2789,31 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ValidatedConfig"
+  "/v1/config_validate_v2":
+    post:
+      tags:
+        - config_validator_v2
+      summary: Validate configuration on the v2 endpoint of the service
+      operationId: validateConfigV2
+      description: |-
+        Validates that an already parsed fluentbit config is semantically valid under the V2 error specification
+        To parse the raw agent config take a look at https://github.com/calyptia/fluent-bit-config-parser.
+      security:
+        - user: []
+        - project: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ValidatingConfig"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ValidatedConfigV2"
+
 # TODO: due to limitations on the way x-msgpack body fields are processed
 # by schemathesis, we aren't not exposing this endpoint yet until
 # we have a valid cmetrics encoder.

--- a/types/config_validator.go
+++ b/types/config_validator.go
@@ -25,3 +25,30 @@ type ConfigValidity struct {
 	Output  map[string][]string `json:"output"`
 	Filter  map[string][]string `json:"filter"`
 }
+
+// ConfigValidityV2Property property details.
+type ConfigValidityV2Property struct {
+	ID       string   `json:"id"`
+	Property string   `json:"property"`
+	Text     string   `json:"text"`
+	Errors   []string `json:"errors"`
+}
+
+// ConfigValidityV2Runtime runtime details.
+type ConfigValidityV2Runtime struct {
+	ID     string   `json:"id"`
+	Errors []string `json:"errors"`
+}
+
+// ConfigValidityV2 details.
+type ConfigValidityV2 struct {
+	Runtime []ConfigValidityV2Runtime             `json:"runtime" `
+	Input   map[string][]ConfigValidityV2Property `json:"input"`
+	Output  map[string][]ConfigValidityV2Property `json:"output"`
+	Filter  map[string][]ConfigValidityV2Property `json:"filter"`
+}
+
+// ValidatedConfigV2 response body after validating an agent config successfully against the v2 endpoint.
+type ValidatedConfigV2 struct {
+	Errors ConfigValidityV2 `json:"errors"`
+}


### PR DESCRIPTION

# Summary of this proposal

* Adds spec definition for v2
* Adds client method for calling config_validate_v2

Signed-off-by: Jorge Niedbalski <j@calyptia.com>

## Notes for the reviewer

* Validated with schemathesis and open-api linters.

## Issue(s) number(s)

Please see https://github.com/calyptia/cloud/pull/331

## Checklist for submitter

- [ ] My PR has a related issue/bug number.
- [X] My PR provides tests
  - [X] Integration tests are added/passes
  - [X] Unit tests are added/passes
  - [ ] End-to-end tests added/passes
  - [ ] Static code check added/passes
  - [X] Linting on documentation added/passes
  - [ ] Does not affect code coverage stats
- [ ] My PR requires updating dependencies
- [X] My PR has the documentation changes required.

## Checklist for reviewer

- [ ] The proposal fixes a bug/issue or implements a new feature that is well described.
- [ ] The proposal has sufficient test cases that covers the changes.
  - [ ] If changes an API, it does not break backwards compatibility (-1 major version).
- [ ] If integration is required, the proposal has integration tests.
- [ ] The proposal does not break coverage stats
- [ ] The proposal has the required documentation changes.

## Backport

<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backport to the current or earlier releases then please submit
a PR for that particular branch.
-->

- [ ] Backport to the latest stable release.