### PR TITLE
client: fix raw config not trimmed in tests

### DIFF
--- a/client/pipeline_test.go
+++ b/client/pipeline_test.go
@@ -11,15 +11,12 @@ import (
 	"github.com/calyptia/api/types"
 )
 
-const testFbitConfigWithAddr = `
-[INPUT]
+const testFbitConfigWithAddr = `[INPUT]
 	Name 			  forward
 	Listen            0.0.0.0
-	Port              24224
-`
+	Port              24224`
 
-const testFbitConfigWithAddr3 = `
-[INPUT]
+const testFbitConfigWithAddr3 = `[INPUT]
 	Name              forward
 	Listen            0.0.0.0
 	Port              24224
@@ -32,8 +29,7 @@ const testFbitConfigWithAddr3 = `
 	Name     syslog.1
 	Listen   0.0.0.0
 	Port     5140
-	Mode     udp
-`
+	Mode     udp`
 
 func TestClient_CreatePipeline(t *testing.T) {
 	ctx := context.Background()


### PR DESCRIPTION
# Summary of this proposal

Due to recent changes in Cloud, now the rawConfig is being trimmed and the tests here were expecting an untrimmed config.

https://github.com/calyptia/cloud/pull/327

## Checklist for submitter

- [ ] My PR has a related issue/bug number.
- [x] My PR provides tests
  - [x] Integration tests are added/passes
  - [ ] Unit tests are added/passes
  - [ ] End-to-end tests added/passes
  - [ ] Static code check added/passes
  - [ ] Linting on documentation added/passes
  - [ ] Does not affect code coverage stats
- [ ] My PR requires updating dependencies
- [ ] My PR has the documentation changes required.

## Checklist for reviewer

- [ ] The proposal fixes a bug/issue or implements a new feature that is well described.
- [ ] The proposal has sufficient test cases that covers the changes.
  - [ ] If changes an API, it does not break backwards compatibility (-1 major version).
- [ ] If integration is required, the proposal has integration tests.
- [ ] The proposal does not break coverage stats
- [ ] The proposal has the required documentation changes.

## Backport

<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backport to the current or earlier releases then please submit
a PR for that particular branch.
-->

- [ ] Backport to the latest stable release.