### PR TITLE
spec: invert servers order as prod, dev, local

### DIFF
--- a/spec/open-api.yml
+++ b/spec/open-api.yml
@@ -9,15 +9,15 @@ info:
     url: "https://cloud.calyptia.com"
   termsOfService: "https://calyptia.com/terms/"
 servers:
+  - url: "https://cloud-api.calyptia.com"
+    description: prod
+  - url: "https://cloud-api-dev.calyptia.com"
+    description: dev
   - url: "http://localhost:{port}"
     description: local
     variables:
       port:
         default: "5000"
-  - url: "https://cloud-api-dev.calyptia.com"
-    description: dev
-  - url: "https://cloud-api.calyptia.com"
-    description: prod
 tags:
   - name: user
   - name: project
@@ -2815,42 +2815,42 @@ paths:
               schema:
                 $ref: "#/components/schemas/ValidatedConfigV2"
 
-# TODO: due to limitations on the way x-msgpack body fields are processed
-# by schemathesis, we aren't not exposing this endpoint yet until
-# we have a valid cmetrics encoder.
-#"/v1/agent_metrics":
-#    post:
-#      tags:
-#        - metric
-#      summary: Add agent metrics
-#      operationId: addAgentMetrics
-#      description: |-
-#        Store the incomming metrics from the agent.
-#      security:
-#        - project: []
-#      requestBody:
-#        content:
-#          application/x-msgpack:
-#            schema:
-#              type: string
-#              format: binary
-#              description: |-
-#                Msgpack encoded metrics using cmetrics library.
-#      responses:
-#        "201":
-#          description: Created
-#          content:
-#            application/json:
-#              schema:
-#                type: object
-#                description: Total number of inserted metrics.
-#                properties:
-#                  totalInserted:
-#                    type: integer
-#                    format: int64
-#                    minimum: 0
-#                required:
-#                  - totalInserted
+  # TODO: due to limitations on the way x-msgpack body fields are processed
+  # by schemathesis, we aren't not exposing this endpoint yet until
+  # we have a valid cmetrics encoder.
+  #"/v1/agent_metrics":
+  #    post:
+  #      tags:
+  #        - metric
+  #      summary: Add agent metrics
+  #      operationId: addAgentMetrics
+  #      description: |-
+  #        Store the incomming metrics from the agent.
+  #      security:
+  #        - project: []
+  #      requestBody:
+  #        content:
+  #          application/x-msgpack:
+  #            schema:
+  #              type: string
+  #              format: binary
+  #              description: |-
+  #                Msgpack encoded metrics using cmetrics library.
+  #      responses:
+  #        "201":
+  #          description: Created
+  #          content:
+  #            application/json:
+  #              schema:
+  #                type: object
+  #                description: Total number of inserted metrics.
+  #                properties:
+  #                  totalInserted:
+  #                    type: integer
+  #                    format: int64
+  #                    minimum: 0
+  #                required:
+  #                  - totalInserted
   "/v1/projects/{projectID}/metrics":
     parameters:
       - schema:
@@ -2997,8 +2997,8 @@ paths:
             format: duration
             default: 1h
       security:
-        - user: [ ]
-        - project: [ ]
+        - user: []
+        - project: []
       summary: Aggregator metrics
       operationId: aggregatorMetrics
       tags:


### PR DESCRIPTION
# Summary of this proposal

Simply inverting the servers order. `prod` is at the top now.
That might make it the default choice for different tooling.

## Checklist for submitter

- [ ] My PR has a related issue/bug number.
- [ ] My PR provides tests
  - [ ] Integration tests are added/passes
  - [ ] Unit tests are added/passes
  - [ ] End-to-end tests added/passes
  - [ ] Static code check added/passes
  - [ ] Linting on documentation added/passes
  - [ ] Does not affect code coverage stats
- [ ] My PR requires updating dependencies
- [x] My PR has the documentation changes required.

## Checklist for reviewer

- [ ] The proposal fixes a bug/issue or implements a new feature that is well described.
- [ ] The proposal has sufficient test cases that covers the changes.
  - [ ] If changes an API, it does not break backwards compatibility (-1 major version).
- [ ] If integration is required, the proposal has integration tests.
- [ ] The proposal does not break coverage stats
- [ ] The proposal has the required documentation changes.

## Backport

<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backport to the current or earlier releases then please submit
a PR for that particular branch.
-->

- [ ] Backport to the latest stable release.