### PR TITLE
tests: use a single variable for locating the cloud image.

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -432,6 +432,7 @@ func setupCloud(pool *dockertest.Pool, conf setupCloudConfig) (*dockertest.Resou
 	splitDockerImage := strings.SplitN(testCloudImage, ":", 2)
 	if len(splitDockerImage) == 2 {
 		cloudImageTag = splitDockerImage[1]
+		testCloudImage = splitDockerImage[0]
 	} else {
 		cloudImageTag = defaultCloudImageLatestTag
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -48,7 +48,7 @@ var (
 
 var (
 	hostIP                             = env("HOST_IP", dockerHostGateway)
-	testCloudImage                     = env("TEST_CLOUD_IMAGE", "ghcr.io/calyptia/cloud")
+	testCloudImage                     = env("TEST_CLOUD_IMAGE", "ghcr.io/calyptia/cloud:main")
 	testCloudPort                      = env("TEST_CLOUD_PORT", "5000")
 	testFluentbitConfigValidatorAPIKey = os.Getenv("TEST_FLUENTBIT_CONFIG_VALIDATOR_API_KEY")
 	testFluentdConfigValidatorAPIKey   = os.Getenv("TEST_FLUENTD_CONFIG_VALIDATOR_API_KEY")

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -37,7 +37,8 @@ import (
 )
 
 const (
-	dockerHostGateway = "host-gateway"
+	dockerHostGateway          = "host-gateway"
+	defaultCloudImageLatestTag = "main"
 )
 
 var (
@@ -48,7 +49,6 @@ var (
 var (
 	hostIP                             = env("HOST_IP", dockerHostGateway)
 	testCloudImage                     = env("TEST_CLOUD_IMAGE", "ghcr.io/calyptia/cloud")
-	testCloudImageTag                  = env("TEST_CLOUD_IMAGE_TAG", "main")
 	testCloudPort                      = env("TEST_CLOUD_PORT", "5000")
 	testFluentbitConfigValidatorAPIKey = os.Getenv("TEST_FLUENTBIT_CONFIG_VALIDATOR_API_KEY")
 	testFluentdConfigValidatorAPIKey   = os.Getenv("TEST_FLUENTD_CONFIG_VALIDATOR_API_KEY")
@@ -427,7 +427,16 @@ func getAuthConfigForImage(image string) (docker.AuthConfiguration, error) {
 }
 
 func setupCloud(pool *dockertest.Pool, conf setupCloudConfig) (*dockertest.Resource, error) {
-	authConfig, err := getAuthConfigForImage(testCloudImage)
+	var cloudImageTag string
+
+	splitDockerImage := strings.Split(testCloudImage, ":")
+	if len(splitDockerImage) > 1 {
+		cloudImageTag = splitDockerImage[len(splitDockerImage)-1]
+	} else {
+		cloudImageTag = defaultCloudImageLatestTag
+	}
+
+	authConfig, err := getAuthConfigForImage(splitDockerImage[0])
 	if err != nil {
 		fmt.Println(err.Error())
 	}
@@ -435,7 +444,7 @@ func setupCloud(pool *dockertest.Pool, conf setupCloudConfig) (*dockertest.Resou
 	return pool.RunWithOptions(&dockertest.RunOptions{
 		Auth:       authConfig,
 		Repository: testCloudImage,
-		Tag:        testCloudImageTag,
+		Tag:        cloudImageTag,
 		Env: []string{
 			"PORT=" + conf.port,
 			"ORIGIN=http://localhost:" + conf.port,

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -429,7 +429,7 @@ func getAuthConfigForImage(image string) (docker.AuthConfiguration, error) {
 func setupCloud(pool *dockertest.Pool, conf setupCloudConfig) (*dockertest.Resource, error) {
 	var cloudImageTag string
 
-	splitDockerImage := strings.Split(testCloudImage, ":")
+	splitDockerImage := strings.SplitN(testCloudImage, ":", 2)
 	if len(splitDockerImage) == 2 {
 		cloudImageTag = splitDockerImage[1]
 	} else {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -431,7 +431,7 @@ func setupCloud(pool *dockertest.Pool, conf setupCloudConfig) (*dockertest.Resou
 
 	splitDockerImage := strings.Split(testCloudImage, ":")
 	if len(splitDockerImage) > 1 {
-		cloudImageTag = splitDockerImage[len(splitDockerImage)-1]
+		cloudImageTag = splitDockerImage[1]
 	} else {
 		cloudImageTag = defaultCloudImageLatestTag
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -430,7 +430,7 @@ func setupCloud(pool *dockertest.Pool, conf setupCloudConfig) (*dockertest.Resou
 	var cloudImageTag string
 
 	splitDockerImage := strings.Split(testCloudImage, ":")
-	if len(splitDockerImage) > 1 {
+	if len(splitDockerImage) == 2 {
 		cloudImageTag = splitDockerImage[1]
 	} else {
 		cloudImageTag = defaultCloudImageLatestTag


### PR DESCRIPTION
# Summary of this proposal

- Allow TEST_CLOUD_IMAGE to be a full docker image path + tag.

Signed-off-by: Jorge Niedbalski <j@calyptia.com>

## Notes for the reviewer

N/A

## Issue(s) number(s)

N/A

## Checklist for submitter

- [X] My PR has the documentation changes required.

## Checklist for reviewer

- [ ] The proposal fixes a bug/issue or implements a new feature that is well described.
- [ ] The proposal has sufficient test cases that covers the changes.
  - [ ] If changes an API, it does not break backwards compatibility (-1 major version).
- [ ] If integration is required, the proposal has integration tests.
- [ ] The proposal does not break coverage stats
- [ ] The proposal has the required documentation changes.

## Backport

<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backport to the current or earlier releases then please submit
a PR for that particular branch.
-->

- [ ] Backport to the latest stable release.