### PR TITLE
Agents pagination

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     name: PR - Linters
     steps:
+      - name: Setup Golang
+        uses: actions/setup-go@v2
+
       - name: Checkout
         uses: actions/checkout@v2
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
       - name: Setup Golang
         uses: actions/setup-go@v2
+        with:
+          go-version: "^1.17"
 
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Go Lint
         uses: golangci/golangci-lint-action@v3.1.0
         with:
-          version: v1.43.0
+          version: v1.44.2
 
       - name: Run golangci lint
         if: github.event_name == 'pull_request'

--- a/README.md
+++ b/README.md
@@ -64,5 +64,8 @@ Or preview it using [SwaggerUI](https://editor.swagger.io/?url=https://raw.githu
 Example using [openapi-typescript-codegen](https://www.npmjs.com/package/openapi-typescript-codegen).
 
 ```bash
-npx openapi-typescript-codegen --input ./spec/open-api.yml --output ./ts-client --name Client
+npx openapi-typescript-codegen \
+    --input ./spec/open-api.yml \
+    --output ./ts-client \
+    --name Client
 ```

--- a/README.md
+++ b/README.md
@@ -64,5 +64,5 @@ Or preview it using [SwaggerUI](https://editor.swagger.io/?url=https://raw.githu
 Example using [openapi-typescript-codegen](https://www.npmjs.com/package/openapi-typescript-codegen).
 
 ```bash
-npx openapi-typescript-codegen --input ./spec/open-api.yml --output ./ts-client
+npx openapi-typescript-codegen --input ./spec/open-api.yml --output ./ts-client --name Client
 ```

--- a/client/agent.go
+++ b/client/agent.go
@@ -32,7 +32,7 @@ func (c *Client) Agents(ctx context.Context, projectID string, params types.Agen
 
 	var out types.Agents
 	path := "/v1/projects/" + url.PathEscape(projectID) + "/agents?" + q.Encode()
-	return out, c.do(ctx, http.MethodGet, path, nil, &out.Items)
+	return out, c.do(ctx, http.MethodGet, path, nil, &out.Items, withCursor(&out.EndCursor))
 }
 
 // Agent by ID.

--- a/client/agent_test.go
+++ b/client/agent_test.go
@@ -103,7 +103,7 @@ func TestClient_Agents(t *testing.T) {
 		})
 		wantEqual(t, err, nil)
 		wantEqual(t, len(page1.Items), 3)
-		wantNoEqual(t, page1.EndCursor, nil)
+		wantNoEqual(t, page1.EndCursor, (*string)(nil))
 
 		page2, err := asUser.Agents(ctx, project.ID, types.AgentsParams{
 			Last:   ptrUint64(3),
@@ -111,7 +111,7 @@ func TestClient_Agents(t *testing.T) {
 		})
 		wantEqual(t, err, nil)
 		wantEqual(t, len(page2.Items), 3)
-		wantNoEqual(t, page2.EndCursor, nil)
+		wantNoEqual(t, page2.EndCursor, (*string)(nil))
 
 		wantNoEqual(t, page1.Items, page2.Items)
 		wantNoEqual(t, *page1.EndCursor, *page2.EndCursor)

--- a/client/agent_test.go
+++ b/client/agent_test.go
@@ -1,11 +1,9 @@
-//go:build integration
-// +build integration
-
 package client_test
 
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/calyptia/api/types"
@@ -73,20 +71,52 @@ func TestClient_Agents(t *testing.T) {
 	project := defaultProject(t, asUser)
 	got, err := asUser.Agents(ctx, project.ID, types.AgentsParams{})
 	wantEqual(t, err, nil)
-	wantEqual(t, len(got), 1)
-	wantEqual(t, got[0].ID, registered.ID)
-	wantEqual(t, got[0].Name, registered.Name)
-	wantEqual(t, got[0].Token, registered.Token)
-	wantEqual(t, got[0].MachineID, "test-machine-id")
-	wantEqual(t, got[0].Type, types.AgentTypeFluentBit)
-	wantEqual(t, got[0].Version, "1.8.6")
-	wantEqual(t, got[0].Edition, types.AgentEditionCommunity)
-	wantEqual(t, got[0].Flags, []string{"test-flag"})
-	wantEqual(t, got[0].RawConfig, "test-raw-config")
-	wantEqual(t, got[0].Metadata, &rawMetadata)
-	wantNoTimeZero(t, got[0].CreatedAt)
+	wantEqual(t, len(got.Items), 1)
+	wantEqual(t, got.Items[0].ID, registered.ID)
+	wantEqual(t, got.Items[0].Name, registered.Name)
+	wantEqual(t, got.Items[0].Token, registered.Token)
+	wantEqual(t, got.Items[0].MachineID, "test-machine-id")
+	wantEqual(t, got.Items[0].Type, types.AgentTypeFluentBit)
+	wantEqual(t, got.Items[0].Version, "1.8.6")
+	wantEqual(t, got.Items[0].Edition, types.AgentEditionCommunity)
+	wantEqual(t, got.Items[0].Flags, []string{"test-flag"})
+	wantEqual(t, got.Items[0].RawConfig, "test-raw-config")
+	wantEqual(t, got.Items[0].Metadata, &rawMetadata)
+	wantNoTimeZero(t, got.Items[0].CreatedAt)
 
 	// skipping metrics tests here.
+
+	t.Run("pagination", func(t *testing.T) {
+		for i := 0; i < 10; i++ {
+			_, err := withToken.RegisterAgent(ctx, types.RegisterAgent{
+				Name:      fmt.Sprintf("test-agent-%d", i),
+				MachineID: fmt.Sprintf("test-machine-id-%d", i), // unique machine id otherwise it gets upserted.
+				Type:      types.AgentTypeFluentBit,
+				Version:   "v1.8.6",
+				Edition:   types.AgentEditionCommunity,
+			})
+			wantEqual(t, err, nil)
+		}
+
+		page1, err := asUser.Agents(ctx, project.ID, types.AgentsParams{
+			Last: ptrUint64(3),
+		})
+		wantEqual(t, err, nil)
+		wantEqual(t, len(page1.Items), 3)
+		wantNoEqual(t, page1.EndCursor, nil)
+
+		page2, err := asUser.Agents(ctx, project.ID, types.AgentsParams{
+			Last:   ptrUint64(3),
+			Before: page1.EndCursor,
+		})
+		wantEqual(t, err, nil)
+		wantEqual(t, len(page2.Items), 3)
+		wantNoEqual(t, page2.EndCursor, nil)
+
+		wantNoEqual(t, page1.Items, page2.Items)
+		wantNoEqual(t, *page1.EndCursor, *page2.EndCursor)
+		wantEqual(t, page1.Items[2].CreatedAt.After(page2.Items[0].CreatedAt), true)
+	})
 }
 
 func TestClient_Agent(t *testing.T) {

--- a/client/client.go
+++ b/client/client.go
@@ -10,8 +10,9 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/calyptia/api/types"
 	"github.com/peterhellberg/link"
+
+	"github.com/calyptia/api/types"
 )
 
 const (

--- a/client/client.go
+++ b/client/client.go
@@ -78,6 +78,7 @@ func (c *Client) setRequestHeaders(req *http.Request) {
 	}
 }
 
+//nolint:dupl // TODO: simplify api and maybe export it.
 func (c *Client) do(ctx context.Context, method, path string, v, dest interface{}, oo ...opt) error {
 	var options opts
 	for _, o := range oo {

--- a/client/client.go
+++ b/client/client.go
@@ -8,8 +8,10 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 
 	"github.com/calyptia/api/types"
+	"github.com/peterhellberg/link"
 )
 
 const (
@@ -75,7 +77,12 @@ func (c *Client) setRequestHeaders(req *http.Request) {
 	}
 }
 
-func (c *Client) do(ctx context.Context, method, path string, v, dest interface{}) error {
+func (c *Client) do(ctx context.Context, method, path string, v, dest interface{}, oo ...opt) error {
+	var options opts
+	for _, o := range oo {
+		o(&options)
+	}
+
 	var body io.Reader
 
 	if b, ok := v.(io.Reader); ok {
@@ -121,6 +128,17 @@ func (c *Client) do(ctx context.Context, method, path string, v, dest interface{
 		return e
 	}
 
+	if s := resp.Header.Get("Link"); s != "" && options.cursor != nil {
+		before, err := nextLinkBefore(s)
+		if err != nil {
+			return err
+		}
+
+		if before != "" {
+			*options.cursor = &before
+		}
+	}
+
 	if dest != nil {
 		err = json.NewDecoder(resp.Body).Decode(dest)
 		if err != nil {
@@ -129,4 +147,41 @@ func (c *Client) do(ctx context.Context, method, path string, v, dest interface{
 	}
 
 	return nil
+}
+
+type opts struct {
+	cursor **string
+}
+
+type opt func(*opts)
+
+func withCursor(s **string) opt {
+	return func(o *opts) {
+		o.cursor = s
+	}
+}
+
+// nextLinkBefore parses the given `Link` header
+// and extracts the `?before=` query string parameter
+// from the URI.
+// It can return an empty string.
+func nextLinkBefore(s string) (string, error) {
+	for _, l := range link.Parse(s) {
+		if l.Rel != "next" {
+			continue
+		}
+
+		u, err := url.Parse(l.URI)
+		if err != nil {
+			return "", fmt.Errorf("could not parse link header uri: %w", err)
+		}
+
+		if !u.Query().Has("before") {
+			continue
+		}
+
+		return u.Query().Get("before"), nil
+	}
+
+	return "", nil
 }

--- a/client/client.go
+++ b/client/client.go
@@ -1,6 +1,7 @@
 // Package client provides a client over the REST HTTP API of Calyptia Cloud.
 package client
 
+//nolint:gci // using goimports
 import (
 	"bytes"
 	"context"
@@ -78,7 +79,7 @@ func (c *Client) setRequestHeaders(req *http.Request) {
 	}
 }
 
-//nolint:dupl // TODO: simplify api and maybe export it.
+//nolint:gocyclo // TODO: simplify api and maybe export it.
 func (c *Client) do(ctx context.Context, method, path string, v, dest interface{}, oo ...opt) error {
 	var options opts
 	for _, o := range oo {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,5 +1,6 @@
 package client_test
 
+//nolint:gci // using goimports
 import (
 	"context"
 	"crypto/rand"

--- a/client/pipeline_file.go
+++ b/client/pipeline_file.go
@@ -1,3 +1,4 @@
+//nolint:dupl // Certain level of code duplication is a good trade off to avoid complexity.
 package client
 
 import (

--- a/client/pipeline_port.go
+++ b/client/pipeline_port.go
@@ -1,3 +1,4 @@
+//nolint:dupl // Certain level of code duplication is a good trade off to avoid complexity.
 package client
 
 import (

--- a/client/pipeline_secret.go
+++ b/client/pipeline_secret.go
@@ -1,3 +1,4 @@
+//nolint:dupl // Certain level of code duplication is a good trade off to avoid complexity.
 package client
 
 import (

--- a/client/project_test.go
+++ b/client/project_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package client_test
 
 import (
@@ -32,15 +29,15 @@ func TestClient_Projects(t *testing.T) {
 	asUser := userClient(t)
 	got, err := asUser.Projects(ctx, types.ProjectsParams{})
 	wantEqual(t, err, nil)
-	wantEqual(t, len(got), 1) // a default project must be created for the user as a side-effect.
-	wantNoEqual(t, got[0].ID, "")
-	wantEqual(t, got[0].Name, "default")
-	wantEqual(t, got[0].MembersCount, uint64(1))
-	wantNoTimeZero(t, got[0].CreatedAt)
-	wantNoEqual(t, got[0].Membership, nil)
-	wantNoEqual(t, got[0].Membership.ID, "")
-	wantNoTimeZero(t, got[0].Membership.CreatedAt)
-	wantEqual(t, got[0].Membership.Roles, []types.MembershipRole{types.MembershipRoleCreator})
+	wantEqual(t, len(got.Items), 1) // a default project must be created for the user as a side-effect.
+	wantNoEqual(t, got.Items[0].ID, "")
+	wantEqual(t, got.Items[0].Name, "default")
+	wantEqual(t, got.Items[0].MembersCount, uint64(1))
+	wantNoTimeZero(t, got.Items[0].CreatedAt)
+	wantNoEqual(t, got.Items[0].Membership, nil)
+	wantNoEqual(t, got.Items[0].Membership.ID, "")
+	wantNoTimeZero(t, got.Items[0].Membership.CreatedAt)
+	wantEqual(t, got.Items[0].Membership.Roles, []types.MembershipRole{types.MembershipRoleCreator})
 }
 
 func TestClient_Project(t *testing.T) {

--- a/client/resource_profile.go
+++ b/client/resource_profile.go
@@ -1,3 +1,4 @@
+//nolint:dupl // Certain level of code duplication is a good trade off to avoid complexity.
 package client
 
 import (

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/opencontainers/image-spec v1.0.2 // indirect
 	github.com/opencontainers/runc v1.0.2 // indirect
+	github.com/peterhellberg/link v1.1.0
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect

--- a/go.sum
+++ b/go.sum
@@ -210,6 +210,8 @@ github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417/go.m
 github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xAPP8dBsCoU0KuF8=
 github.com/ory/dockertest/v3 v3.8.1 h1:vU/8d1We4qIad2YM0kOwRVtnyue7ExvacPiw1yDm17g=
 github.com/ory/dockertest/v3 v3.8.1/go.mod h1:wSRQ3wmkz+uSARYMk7kVJFDBGm8x5gSxIhI7NDc+BAQ=
+github.com/peterhellberg/link v1.1.0 h1:s2+RH8EGuI/mI4QwrWGSYQCRz7uNgip9BaM04HKu5kc=
+github.com/peterhellberg/link v1.1.0/go.mod h1:gtSlOT4jmkY8P47hbTc8PTgiDDWpdPbFYl75keYyBB8=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/spec/open-api.yml
+++ b/spec/open-api.yml
@@ -1869,11 +1869,27 @@ paths:
         - schema:
             type: string
           in: query
+          name: before
+          description: Agents before the given cursor.
+        - schema:
+            type: string
+          in: query
           name: name
           description: Name matching agents.
       responses:
         "200":
           description: OK
+          headers:
+            Link:
+              schema:
+                type: string
+                example: </v1/projects/foo/agents?before=bar>; rel="next"
+              description: RFC5988 with `rel="next"`.
+          links:
+            NextAgentsPage:
+              operationId: agents
+              parameters:
+                before: "$response.header.Link#rel=next"
           content:
             application/json:
               schema:


### PR DESCRIPTION
# Summary of this proposal

Adding tests for the new paginated agents.
Adding the spec for the new paginated agents endpoint.
Update readme TS client codegen command to include a client.

## Notes for the reviewer

The generated TS client doesn't expose the headers in the resolved responses. See https://github.com/ferdikoomen/openapi-typescript-codegen/blob/b3530b14fc82ba285ff7940c750f50f37dd32bdb/test/__snapshots__/index.spec.ts.snap#L524

Related issue https://github.com/ferdikoomen/openapi-typescript-codegen/issues/829

We might have to switch the code generator, or fork it, or take a look at the `--request` option.

## Issue(s) number(s)

https://github.com/calyptia/api/issues/50

## Checklist for submitter

- [ ] My PR has a related issue/bug number.
- [x] My PR provides tests
  - [x] Integration tests are added/passes
  - [ ] Unit tests are added/passes
  - [ ] End-to-end tests added/passes
  - [ ] Static code check added/passes
  - [ ] Linting on documentation added/passes
  - [ ] Does not affect code coverage stats
- [ ] My PR requires updating dependencies
- [ ] My PR has the documentation changes required.

## Checklist for reviewer

- [ ] The proposal fixes a bug/issue or implements a new feature that is well described.
- [ ] The proposal has sufficient test cases that covers the changes.
  - [ ] If changes an API, it does not break backwards compatibility (-1 major version).
- [ ] If integration is required, the proposal has integration tests.
- [ ] The proposal does not break coverage stats
- [ ] The proposal has the required documentation changes.

## Backport

<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backport to the current or earlier releases then please submit
a PR for that particular branch.
-->

- [ ] Backport to the latest stable release.