### PR TITLE
github/workflows: bump lint version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v2
         with:
-          go-version: "^1.17"
+          go-version: "^1.18"
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -18,7 +18,7 @@ jobs:
       - name: Go Lint
         uses: golangci/golangci-lint-action@v3.1.0
         with:
-          version: v1.44.2
+          version: v1.45.2
 
       - name: Run golangci lint
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
Upgrading linter since I saw this panic in CI:

```txt
panic: load embedded ruleguard rules: rules/rules.go:13: can't load fmt
```

Checking if upgrading the version fixes it.