### PR TITLE
Switch aggregator status to unreachable.

### DIFF
--- a/types/aggregator.go
+++ b/types/aggregator.go
@@ -27,9 +27,9 @@ type Aggregator struct {
 type AggregatorStatus string
 
 const (
-	AggregatorStatusWaiting    AggregatorStatus = "waiting"
-	AggregatorStatusRunning    AggregatorStatus = "running"
-	AggregatorStatusTerminated AggregatorStatus = "terminated"
+	AggregatorStatusWaiting     AggregatorStatus = "waiting"
+	AggregatorStatusRunning     AggregatorStatus = "running"
+	AggregatorStatusUnreachable AggregatorStatus = "unreachable"
 )
 
 // Aggregators paginated list.

--- a/types/aggregator.go
+++ b/types/aggregator.go
@@ -32,12 +32,14 @@ const (
 	AggregatorStatusUnreachable AggregatorStatus = "unreachable"
 )
 
-// Aggregator ping constants
+// Aggregator ping constants.
 const (
 	// AggregatorNextPing is the time between pings to an aggregator.
 	AggregatorNextPing = time.Second * 30
+	// AggregatorNextPingDelta is the extra time acceptable for a ping to be delayed.
+	AggregatorNextPingDelta = time.Second * 5
 	// AggregatorNextPingTimeout is the time after an aggregator is considered "unreachable".
-	AggregatorNextPingTimeout = AggregatorNextPing + (time.Second * 5)
+	AggregatorNextPingTimeout = AggregatorNextPing + AggregatorNextPingDelta
 )
 
 // Aggregators paginated list.

--- a/types/aggregator.go
+++ b/types/aggregator.go
@@ -32,6 +32,14 @@ const (
 	AggregatorStatusUnreachable AggregatorStatus = "unreachable"
 )
 
+// Aggregator ping constants
+const (
+	// AggregatorNextPing is the time between pings to an aggregator.
+	AggregatorNextPing = time.Second * 30
+	// AggregatorNextPingTimeout is the time after an aggregator is considered "unreachable".
+	AggregatorNextPingTimeout = AggregatorNextPing + (time.Second * 5)
+)
+
 // Aggregators paginated list.
 type Aggregators struct {
 	Items     []Aggregator


### PR DESCRIPTION
Ping semantics uses "unreachable" for icmp unreach
not terminated as it indicates that the aggregator has been
terminated (but can be a failure on communication or other).

Signed-off-by: Jorge Niedbalski <j@calyptia.com>
