### PR TITLE
types: add public ipv4 calyptia-core instance metadata for AWS

### DIFF
--- a/spec/open-api.yml
+++ b/spec/open-api.yml
@@ -315,6 +315,13 @@ components:
             - running
             - waiting
             - unreachable
+        metadata:
+          type: object
+          nullable: true
+          properties:
+            nodeSelector:
+              type: object
+              nullable: true
         pipelinesCount:
           type: integer
           format: int64
@@ -978,6 +985,13 @@ components:
           type: integer
           format: int32
           minimum: 0
+        metadata:
+          type: object
+          nullable: true
+          properties:
+            nodeSelector:
+              type: object
+              nullable: true
       required:
         - name
         - version
@@ -996,6 +1010,13 @@ components:
           type: string
           example: v0.1.12
           nullable: true
+        metadata:
+          type: object
+          nullable: true
+          properties:
+            nodeSelector:
+              type: object
+              nullable: true
     CreateResourceProfile:
       description: Create resource profile request body.
       type: object

--- a/types/aggregator.go
+++ b/types/aggregator.go
@@ -80,7 +80,8 @@ type MetadataAWS struct {
 	AccountID       string `json:"aws.account_id"`
 	Hostname        string `json:"aws.hostname"`
 	VPCID           string `json:"aws.vpc_id"`
-	PrivateIP       string `json:"aws.private_ip"`
+	PrivateIPv4     string `json:"aws.private_ipv4"`
+	PublicIPv4      string `json:"aws.public_ipv4"`
 	EC2InstanceID   string `json:"aws.ec2_instance_id"`
 	EC2InstanceType string `json:"aws.ec2_instance_type"`
 	AZ              string `json:"aws.az"`


### PR DESCRIPTION
# Summary of this proposal

- Add PublicIPv4 metadata attribute for AWS.
- Rename PrivateIP to PrivateIPv4
- Add tests to assert update of metadata properties.

Fixes #112 

Signed-off-by: Jorge Niedbalski <j@calyptia.com>

