### PR TITLE
Add environment ID, name to agent, aggregator specs.

### DIFF
--- a/spec/open-api.yml
+++ b/spec/open-api.yml
@@ -247,6 +247,10 @@ components:
         updatedAt:
           type: string
           format: date-time
+        environmentName:
+          type: string
+          default: default
+          example: default
       required:
         - id
         - token
@@ -334,6 +338,10 @@ components:
           uniqueItems: true
           items:
             type: string
+        environmentName:
+          type: string
+          default: default
+          example: default
       required:
         - id
         - token
@@ -926,6 +934,10 @@ components:
         metadata:
           type: object
           nullable: true
+        environmentID:
+          type: string
+          nullable: true
+          description: environment ID to associate this agent with.
       required:
         - name
         - machineID
@@ -964,6 +976,10 @@ components:
         metadata:
           type: object
           nullable: true
+        environmentID:
+          type: string
+          nullable: true
+          description: environment ID to associate this agent with.
     CreateAggregator:
       description: Create aggregator request body.
       type: object
@@ -984,6 +1000,10 @@ components:
         metadata:
           type: object
           nullable: true
+        environmentID:
+          type: string
+          nullable: true
+          description: environment ID to associate this aggregator with.
       required:
         - name
         - version
@@ -1005,6 +1025,10 @@ components:
         metadata:
           type: object
           nullable: true
+        environmentID:
+          type: string
+          nullable: true
+          description: environment ID to associate this aggregator with.
     CreateResourceProfile:
       description: Create resource profile request body.
       type: object

--- a/spec/open-api.yml
+++ b/spec/open-api.yml
@@ -262,6 +262,7 @@ components:
         - flags
         - rawConfig
         - metadata
+        - environmentName
         - firstMetricsAddedAt
         - lastMetricsAddedAt
         - metricsCount
@@ -347,6 +348,7 @@ components:
         - token
         - name
         - pipelinesCount
+        - environmentName
         - createdAt
         - updatedAt
     ResourceProfile:

--- a/types/agent.go
+++ b/types/agent.go
@@ -77,10 +77,11 @@ type RegisteredAgent struct {
 
 // AgentsParams request payload for querying agents.
 type AgentsParams struct {
-	Last   *uint64
-	Before *string
-	Name   *string
-	Tags   *string
+	Last          *uint64
+	Before        *string
+	Name          *string
+	Tags          *string
+	EnvironmentID *string
 }
 
 // UpdateAgent request payload for updating an agent.

--- a/types/aggregator.go
+++ b/types/aggregator.go
@@ -111,25 +111,25 @@ type CreateAggregator struct {
 
 // CreatedAggregator response payload after creating an aggregator successfully.
 type CreatedAggregator struct {
-	ID            string    `json:"id"`
-	Token         string    `json:"token"`
-	PrivateRSAKey []byte    `json:"privateRSAKey"`
-	PublicRSAKey  []byte    `json:"publicRSAKey"`
-	Name          string    `json:"name"`
-	Version       string    `json:"version"`
-	CreatedAt     time.Time `json:"createdAt"`
-	Tags          []string  `json:"tags"`
-
+	ID                  string            `json:"id"`
+	Token               string            `json:"token"`
+	PrivateRSAKey       []byte            `json:"privateRSAKey"`
+	PublicRSAKey        []byte            `json:"publicRSAKey"`
+	Name                string            `json:"name"`
+	Version             string            `json:"version"`
+	CreatedAt           time.Time         `json:"createdAt"`
+	Tags                []string          `json:"tags"`
 	HealthCheckPipeline *Pipeline         `json:"healthCheckPipeline"`
 	ResourceProfiles    []ResourceProfile `json:"resourceProfiles"`
 }
 
 // AggregatorsParams request payload for querying aggregators.
 type AggregatorsParams struct {
-	Last   *uint64
-	Before *string
-	Name   *string
-	Tags   *string
+	Last          *uint64
+	Before        *string
+	Name          *string
+	Tags          *string
+	EnvironmentID *string
 }
 
 // UpdateAggregator request payload for updating an aggregator.


### PR DESCRIPTION
# Summary of this proposal

- Add the environment ID to the get operations on agent, aggregator.
- Add the environment Name to the create/register operations on agent, aggregator.
- Update the specs.

Signed-off-by: Jorge Niedbalski <j@calyptia.com>


## Issue(s) number(s)

Related to https://github.com/calyptia/cli/issues/97 