### PR TITLE
spec: trace sessions and records

### DIFF
--- a/spec/open-api.yml
+++ b/spec/open-api.yml
@@ -40,6 +40,7 @@ tags:
   - name: environment
   - name: trace_session
   - name: trace_record
+
 components:
   securitySchemes:
     user:
@@ -120,8 +121,8 @@ components:
           example: my-project
         membersCount:
           type: integer
-          minimum: 1
           format: int64
+          minimum: 1
         agentsCount:
           type: integer
           format: int64
@@ -610,8 +611,8 @@ components:
                 type: object
                 additionalProperties:
                   type: number
-                  nullable: true
                   format: float
+                  nullable: true
               plugins:
                 type: object
                 additionalProperties:
@@ -625,8 +626,8 @@ components:
             type: object
             additionalProperties:
               type: number
-              nullable: true
               format: float
+              nullable: true
       required:
         - measurements
         - topPlugins
@@ -844,8 +845,8 @@ components:
           format: date-time
         value:
           type: number
-          nullable: true
           format: float
+          nullable: true
       required:
         - time
         - value
@@ -1188,6 +1189,7 @@ components:
         replicasCount:
           type: integer
           format: int64
+          minimum: 0
           nullable: true
         rawConfig:
           type: string
@@ -1656,10 +1658,12 @@ components:
           type: array
           items:
             type: string
+            example: "dummy.0"
         lifespan:
           description: For how long will this session be active and process records.
           type: string
           format: duration
+          example: "10m"
         createdAt:
           type: string
           format: date-time
@@ -1684,10 +1688,12 @@ components:
           type: array
           items:
             type: string
+            example: "dummy.0"
         lifespan:
           description: For how long will this session be active and process records.
           type: string
           format: duration
+          example: "10m"
       required:
         - plugins
         - lifespan
@@ -1702,11 +1708,13 @@ components:
           type: array
           items:
             type: string
+            example: "dummy.0"
           nullable: true
         lifespan:
           description: For how long will this session be active and process records.
           type: string
           format: duration
+          example: "10m"
           nullable: true
 
     TraceRecord:
@@ -1726,20 +1734,26 @@ components:
           $ref: "#/components/schemas/TraceRecordKind"
         trace_id:
           type: string
+          example: trace.5
         start_time:
-          type: number
           description: Unix timestamp with seconds precision.
+          type: integer
           format: int64
+          example: 1658953439
         end_time:
-          type: number
           description: Unix timestamp with seconds precision.
+          type: integer
           format: int64
+          example: 1658953439
         plugin_instance:
           type: string
+          example: nest.2
         plugin_alias:
           type: string
+          example: nest_2
         return_code:
-          type: number
+          type: integer
+          format: int64
         records:
           type: array
           items:
@@ -1747,10 +1761,21 @@ components:
             properties:
               timestamp:
                 description: Unix timestamp with seconds precision.
-                type: number
+                type: integer
+                format: int64
+                example: 1658953439
               record:
                 type: object
                 additionalProperties: true
+                example: |-
+                  {
+                    "dummy": "dummy_0",
+                    "powered_by": "calyptia",
+                    "data": {
+                      "key_name": "foo",
+                      "key_cnt": "1"
+                    }
+                  }
             additionalProperties: true
             required:
               - timestamp
@@ -1772,7 +1797,7 @@ components:
         - createdAt
 
     TraceRecordKind:
-      type: number
+      type: integer
       enum: [1, 2, 3, 4]
       # Custom enum names supported by openapi-typescript-codegen.
       # See https://github.com/ferdikoomen/openapi-typescript-codegen/blob/master/docs/custom-enums.md
@@ -1787,20 +1812,25 @@ components:
           $ref: "#/components/schemas/TraceRecordKind"
         trace_id:
           type: string
+          example: trace.5
         start_time:
-          type: number
           description: Unix timestamp with seconds precision.
+          type: integer
           format: int64
+          example: 1658953439
         end_time:
-          type: number
           description: Unix timestamp with seconds precision.
+          type: integer
           format: int64
+          example: 1658953439
         plugin_instance:
           type: string
+          example: nest.2
         plugin_alias:
           type: string
+          example: nest_2
         return_code:
-          type: number
+          type: integer
         records:
           type: array
           items:
@@ -1808,10 +1838,21 @@ components:
             properties:
               timestamp:
                 description: Unix timestamp with seconds precision.
-                type: number
+                type: integer
+                format: int64
+                example: 1658953439
               record:
                 type: object
                 additionalProperties: true
+                example: |-
+                  {
+                    "dummy": "dummy_0",
+                    "powered_by": "calyptia",
+                    "data": {
+                      "key_name": "foo",
+                      "key_cnt": "1"
+                    }
+                  }
             additionalProperties: true
             required:
               - timestamp
@@ -1825,6 +1866,39 @@ components:
         - plugin_alias
         - return_code
         - records
+
+    StoredFields:
+      type: object
+      description: Common stored fields.
+      properties:
+        id:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+      required: [id, createdAt]
+
+    UpdatedFields:
+      type: object
+      description: Common stored fields.
+      properties:
+        updatedAt:
+          type: string
+          format: date-time
+      required: [updatedAt]
+
+    UpdatedFieldsFound:
+      type: object
+      description: Common stored fields.
+      properties:
+        id:
+          type: string
+          format: uuid
+        updatedAt:
+          type: string
+          format: date-time
+      required: [id, updatedAt]
 
 paths:
   /v1/verification_email:
@@ -3617,3 +3691,201 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/AggregatorMetrics"
+
+  "/v1/pipelines/{pipelineID}/trace_sessions":
+    parameters:
+      - name: pipelineID
+        in: path
+        schema:
+          type: string
+          format: uuid
+        required: true
+    post:
+      tags: [trace_session]
+      security:
+        - user: []
+        - project: []
+      summary: Create trace session
+      operationId: createTraceSession
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateTraceSession"
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StoredFields"
+    get:
+      tags: [trace_session]
+      security:
+        - user: []
+        - project: []
+      summary: Trace sessions
+      operationId: traceSessions
+      responses:
+        "200":
+          description: OK
+          headers:
+            Link:
+              schema:
+                type: string
+                example: </v1/pipelines/foo/trace_sessions?before=bar>; rel="next"
+              description: RFC5988 with `rel="next"`.
+          links:
+            NextTraceSessionsPage:
+              operationId: traceSessions
+              parameters:
+                before: "$response.header.Link#rel=next"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/TraceSession"
+
+  "/v1/pipelines/{pipelineID}/trace_session":
+    parameters:
+      - name: pipelineID
+        in: path
+        schema:
+          type: string
+          format: uuid
+        required: true
+    get:
+      tags: [trace_session]
+      security:
+        - user: []
+        - project: []
+      summary: Active trace session
+      operationId: activeTraceSession
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TraceSession"
+    delete:
+      tags: [trace_session]
+      security:
+        - user: []
+        - project: []
+      summary: Terminate active trace session
+      operationId: terminateActiveTraceSession
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UpdatedFieldsFound"
+
+  "/v1/trace_sessions/{sessionID}":
+    parameters:
+      - name: sessionID
+        in: path
+        schema:
+          type: string
+          format: uuid
+        required: true
+    get:
+      tags: [trace_session]
+      security:
+        - user: []
+        - project: []
+      summary: Trace session
+      operationId: traceSession
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TraceSession"
+    patch:
+      tags: [trace_session]
+      security:
+        - user: []
+        - project: []
+      summary: Update trace session
+      operationId: updateTraceSession
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateTraceSession"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UpdatedFields"
+
+  "/v1/pipelines/{pipelineID}/trace_session/records":
+    parameters:
+      - name: pipelineID
+        in: path
+        schema:
+          type: string
+          format: uuid
+        required: true
+    post:
+      tags: [trace_record]
+      security:
+        - user: []
+        - project: []
+      summary: Create trace record
+      operationId: createTraceRecord
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateTraceRecord"
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StoredFields"
+
+  "/v1/trace_sessions/{sessionID}/records":
+    parameters:
+      - name: sessionID
+        in: path
+        schema:
+          type: string
+          format: uuid
+        required: true
+    get:
+      tags: [trace_record]
+      security:
+        - user: []
+        - project: []
+      summary: Trace records
+      operationId: traceRecords
+      responses:
+        "200":
+          description: OK
+          headers:
+            Link:
+              schema:
+                type: string
+                example: </v1/trace_sessions/foo/records?before=bar>; rel="next"
+              description: RFC5988 with `rel="next"`.
+          links:
+            NextTraceRecordsPage:
+              operationId: traceRecords
+              parameters:
+                before: "$response.header.Link#rel=next"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/TraceRecord"

--- a/spec/open-api.yml
+++ b/spec/open-api.yml
@@ -38,6 +38,8 @@ tags:
   - name: config_validator_v2
   - name: metric
   - name: environment
+  - name: trace_session
+  - name: trace_record
 components:
   securitySchemes:
     user:
@@ -472,9 +474,9 @@ components:
         configFormat:
           type: string
           enum:
-              - ini
-              - json
-              - yaml
+            - ini
+            - json
+            - yaml
         createdAt:
           type: string
           format: date-time
@@ -1141,9 +1143,9 @@ components:
         configFormat:
           type: string
           enum:
-              - ini
-              - json
-              - yaml
+            - ini
+            - json
+            - yaml
         secrets:
           type: array
           nullable: true
@@ -1193,9 +1195,9 @@ components:
         configFormat:
           type: string
           enum:
-              - ini
-              - json
-              - yaml
+            - ini
+            - json
+            - yaml
           nullable: true
         secrets:
           type: array
@@ -1635,6 +1637,194 @@ components:
             - filter
       required:
         - errors
+
+    TraceSession:
+      type: object
+      description: |
+        Trace session model.
+        There can only be one active session at a moment on a pipeline.
+        Either terminate it and create a new one, or update and extend the lifespan of the current active one.
+      properties:
+        id:
+          type: string
+          format: uuid
+        pipelineID:
+          type: string
+          format: uuid
+        plugins:
+          description: List of Fluent-bit plugins to trace.
+          type: array
+          items:
+            type: string
+        lifespan:
+          description: For how long will this session be active and process records.
+          type: string
+          format: duration
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - pipelineID
+        - plugins
+        - lifespan
+        - createdAt
+        - updatedAt
+
+    CreateTraceSession:
+      type: object
+      description: |
+        Request body to create a new trace session on a pipeline.
+      properties:
+        plugins:
+          description: List of Fluent-bit plugins to trace.
+          type: array
+          items:
+            type: string
+        lifespan:
+          description: For how long will this session be active and process records.
+          type: string
+          format: duration
+      required:
+        - plugins
+        - lifespan
+
+    UpdateTraceSession:
+      type: object
+      description: |
+        Request body to update an active trace session on a pipeline.
+      properties:
+        plugins:
+          description: List of Fluent-bit plugins to trace.
+          type: array
+          items:
+            type: string
+          nullable: true
+        lifespan:
+          description: For how long will this session be active and process records.
+          type: string
+          format: duration
+          nullable: true
+
+    TraceRecord:
+      type: object
+      description: |
+        Trace record model.
+        Trace Records comming from fluent-bit once trace is enabled.
+        It contains trace records for all the fluen-bit plugins configured on the trace session.
+      properties:
+        id:
+          type: string
+          format: uuid
+        sessionID:
+          type: string
+          format: uuid
+        type:
+          $ref: "#/components/schemas/TraceRecordKind"
+        trace_id:
+          type: string
+        start_time:
+          type: number
+          description: Unix timestamp with seconds precision.
+          format: int64
+        end_time:
+          type: number
+          description: Unix timestamp with seconds precision.
+          format: int64
+        plugin_instance:
+          type: string
+        plugin_alias:
+          type: string
+        return_code:
+          type: number
+        records:
+          type: array
+          items:
+            type: object
+            properties:
+              timestamp:
+                description: Unix timestamp with seconds precision.
+                type: number
+              record:
+                type: object
+                additionalProperties: true
+            additionalProperties: true
+            required:
+              - timestamp
+              - record
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - sessionID
+        - type
+        - trace_id
+        - start_time
+        - end_time
+        - plugin_instance
+        - plugin_alias
+        - return_code
+        - records
+        - createdAt
+
+    TraceRecordKind:
+      type: number
+      enum: [1, 2, 3, 4]
+      # Custom enum names supported by openapi-typescript-codegen.
+      # See https://github.com/ferdikoomen/openapi-typescript-codegen/blob/master/docs/custom-enums.md
+      x-enum-varnames: [INPUT, FILTER, PRE_OUTPUT, OUTPUT]
+
+    CreateTraceRecord:
+      type: object
+      description: |
+        Request body to create a trace record on an active session.
+      properties:
+        type:
+          $ref: "#/components/schemas/TraceRecordKind"
+        trace_id:
+          type: string
+        start_time:
+          type: number
+          description: Unix timestamp with seconds precision.
+          format: int64
+        end_time:
+          type: number
+          description: Unix timestamp with seconds precision.
+          format: int64
+        plugin_instance:
+          type: string
+        plugin_alias:
+          type: string
+        return_code:
+          type: number
+        records:
+          type: array
+          items:
+            type: object
+            properties:
+              timestamp:
+                description: Unix timestamp with seconds precision.
+                type: number
+              record:
+                type: object
+                additionalProperties: true
+            additionalProperties: true
+            required:
+              - timestamp
+              - record
+      required:
+        - type
+        - trace_id
+        - start_time
+        - end_time
+        - plugin_instance
+        - plugin_alias
+        - return_code
+        - records
 
 paths:
   /v1/verification_email:
@@ -3125,8 +3315,8 @@ paths:
       operationId: projectEnvironments
       description: Environments from a project.
       security:
-        - user: [ ]
-        - project: [ ]
+        - user: []
+        - project: []
       parameters:
         - schema:
             type: integer
@@ -3172,8 +3362,8 @@ paths:
       operationId: createEnvironment
       description: Create a environment to a given project.
       security:
-        - user: [ ]
-        - project: [ ]
+        - user: []
+        - project: []
       requestBody:
         content:
           application/json:
@@ -3209,8 +3399,8 @@ paths:
       operationId: updateEnvironments
       description: Updates a given environment
       security:
-        - user: [ ]
-        - project: [ ]
+        - user: []
+        - project: []
       requestBody:
         content:
           application/json:
@@ -3226,13 +3416,11 @@ paths:
       operationId: deleteEnvironment
       description: Delete a given environment
       security:
-        - user: [ ]
-        - project: [ ]
+        - user: []
+        - project: []
       responses:
         "200":
           description: OK
-
-
 
   # TODO: due to limitations on the way x-msgpack body fields are processed
   # by schemathesis, we aren't not exposing this endpoint yet until

--- a/types/trace.go
+++ b/types/trace.go
@@ -76,13 +76,15 @@ const (
 
 // CreateTraceRecord request payload for creating a new trace record.
 type CreateTraceRecord struct {
-	Kind           TraceRecordKind `json:"type"`
-	TraceID        string          `json:"trace_id"`
-	StartTime      time.Time       `json:"start_time"`
-	EndTime        time.Time       `json:"end_time"`
-	PluginInstance string          `json:"plugin_instance"`
-	PluginAlias    string          `json:"plugin_alias"`
-	ReturnCode     int             `json:"return_code"`
+	Kind    TraceRecordKind `json:"type"`
+	TraceID string          `json:"trace_id"`
+	// StartTime in unix seconds.
+	StartTime int64 `json:"start_time"`
+	// EndTime in unix seconds.
+	EndTime        int64  `json:"end_time"`
+	PluginInstance string `json:"plugin_instance"`
+	PluginAlias    string `json:"plugin_alias"`
+	ReturnCode     int    `json:"return_code"`
 	// Records array, each record is a JSON object,
 	// warranted to have a flb_time `timestamp` field.
 	Records json.RawMessage `json:"records"`


### PR DESCRIPTION
# Summary of this proposal

Providing with updated OpenAPI spec to include endpoints for trace sessions and records.

I also did a small change on the types for the records, since fluent-bit uses unix timestamp in seconds to represent time, instead of RFC3339. After merging this, we need to create a new tag and address this change on the Cloud back-end.

## Notes for the reviewer

This PR is just for the spec. The client and tests will come in a separate PR.


## Checklist for submitter

- [ ] My PR has a related issue/bug number.
- [ ] My PR provides tests
  - [ ] Integration tests are added/passes
  - [ ] Unit tests are added/passes
  - [ ] End-to-end tests added/passes
  - [ ] Static code check added/passes
  - [x] Linting on documentation added/passes
  - [ ] Does not affect code coverage stats
- [x] My PR requires updating dependencies
- [x] My PR has the documentation changes required.

## Checklist for reviewer

- [ ] The proposal fixes a bug/issue or implements a new feature that is well described.
- [ ] The proposal has sufficient test cases that covers the changes.
  - [ ] If changes an API, it does not break backwards compatibility (-1 major version).
- [ ] If integration is required, the proposal has integration tests.
- [ ] The proposal does not break coverage stats
- [ ] The proposal has the required documentation changes.

## Backport

<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backport to the current or earlier releases then please submit
a PR for that particular branch.
-->

- [ ] Backport to the latest stable release.