### PR TITLE
change uint64 to uint

### DIFF
--- a/client/agent.go
+++ b/client/agent.go
@@ -21,7 +21,7 @@ func (c *Client) RegisterAgent(ctx context.Context, payload types.RegisterAgent)
 func (c *Client) Agents(ctx context.Context, projectID string, params types.AgentsParams) (types.Agents, error) {
 	q := url.Values{}
 	if params.Last != nil {
-		q.Set("last", strconv.FormatUint(*params.Last, uintBase))
+		q.Set("last", strconv.FormatUint(uint64(*params.Last), uintBase))
 	}
 	if params.Before != nil {
 		q.Set("before", *params.Before)

--- a/client/agent_config.go
+++ b/client/agent_config.go
@@ -14,7 +14,7 @@ import (
 func (c *Client) AgentConfigHistory(ctx context.Context, agentID string, params types.AgentConfigHistoryParams) (types.AgentConfigHistory, error) {
 	q := url.Values{}
 	if params.Last != nil {
-		q.Set("last", strconv.FormatUint(*params.Last, uintBase))
+		q.Set("last", strconv.FormatUint(uint64(*params.Last), uintBase))
 	}
 	if params.Before != nil {
 		q.Set("before", *params.Before)

--- a/client/agent_config_test.go
+++ b/client/agent_config_test.go
@@ -55,9 +55,9 @@ func TestClient_AgentConfigHistory(t *testing.T) {
 		}
 		allConfigs, err := asUser.AgentConfigHistory(ctx, registered.ID, types.AgentConfigHistoryParams{})
 		wantEqual(t, err, nil)
-		page1, err := asUser.AgentConfigHistory(ctx, registered.ID, types.AgentConfigHistoryParams{Last: ptrUint64(3)})
+		page1, err := asUser.AgentConfigHistory(ctx, registered.ID, types.AgentConfigHistoryParams{Last: ptrUint(3)})
 		wantEqual(t, err, nil)
-		page2, err := asUser.AgentConfigHistory(ctx, registered.ID, types.AgentConfigHistoryParams{Last: ptrUint64(3), Before: page1.EndCursor})
+		page2, err := asUser.AgentConfigHistory(ctx, registered.ID, types.AgentConfigHistoryParams{Last: ptrUint(3), Before: page1.EndCursor})
 		wantEqual(t, err, nil)
 
 		want := allConfigs.Items[3:6]

--- a/client/agent_test.go
+++ b/client/agent_test.go
@@ -145,14 +145,14 @@ func TestClient_Agents(t *testing.T) {
 		}
 
 		page1, err := asUser.Agents(ctx, project.ID, types.AgentsParams{
-			Last: ptrUint64(3),
+			Last: ptrUint(3),
 		})
 		wantEqual(t, err, nil)
 		wantEqual(t, len(page1.Items), 3)
 		wantNoEqual(t, page1.EndCursor, (*string)(nil))
 
 		page2, err := asUser.Agents(ctx, project.ID, types.AgentsParams{
-			Last:   ptrUint64(3),
+			Last:   ptrUint(3),
 			Before: page1.EndCursor,
 		})
 		wantEqual(t, err, nil)
@@ -246,20 +246,20 @@ func TestClient_Agents(t *testing.T) {
 
 		envOneAggregators, err := asUser.Agents(ctx, project.ID, types.AgentsParams{
 			EnvironmentID: ptrStr(envOne.ID),
-			Last:          ptrUint64(0),
+			Last:          ptrUint(0),
 		})
 		wantEqual(t, err, nil)
 		wantEqual(t, len(envOneAggregators.Items), 1)
 
 		envTwoAggregators, err := asUser.Agents(ctx, project.ID, types.AgentsParams{
 			EnvironmentID: ptrStr(envTwo.ID),
-			Last:          ptrUint64(0),
+			Last:          ptrUint(0),
 		})
 		wantEqual(t, err, nil)
 		wantEqual(t, len(envTwoAggregators.Items), 1)
 
 		bothEnvsAggregators, err := asUser.Agents(ctx, project.ID, types.AgentsParams{
-			Last: ptrUint64(0),
+			Last: ptrUint(0),
 		})
 		wantEqual(t, err, nil)
 		wantNoEqual(t, len(bothEnvsAggregators.Items), 1)

--- a/client/aggregator.go
+++ b/client/aggregator.go
@@ -21,7 +21,7 @@ func (c *Client) CreateAggregator(ctx context.Context, payload types.CreateAggre
 func (c *Client) Aggregators(ctx context.Context, projectID string, params types.AggregatorsParams) (types.Aggregators, error) {
 	q := url.Values{}
 	if params.Last != nil {
-		q.Set("last", strconv.FormatUint(*params.Last, uintBase))
+		q.Set("last", strconv.FormatUint(uint64(*params.Last), uintBase))
 	}
 	if params.Before != nil {
 		q.Set("before", *params.Before)

--- a/client/aggregator_test.go
+++ b/client/aggregator_test.go
@@ -67,7 +67,7 @@ func TestClient_Aggregators(t *testing.T) {
 	wantEqual(t, got.Items[0].Name, created.Name)
 	wantEqual(t, got.Items[0].Version, created.Version)
 	wantEqual(t, got.Items[0].Token, created.Token)
-	wantEqual(t, got.Items[0].PipelinesCount, uint64(1))
+	wantEqual(t, got.Items[0].PipelinesCount, uint(1))
 	wantEqual(t, got.Items[0].CreatedAt, created.CreatedAt)
 	wantEqual(t, got.Items[0].UpdatedAt, created.CreatedAt)
 	wantEqual(t, got.Items[0].Status, types.AggregatorStatusWaiting)
@@ -82,14 +82,14 @@ func TestClient_Aggregators(t *testing.T) {
 		}
 
 		page1, err := asUser.Aggregators(ctx, project.ID, types.AggregatorsParams{
-			Last: ptrUint64(3),
+			Last: ptrUint(3),
 		})
 		wantEqual(t, err, nil)
 		wantEqual(t, len(page1.Items), 3)
 		wantNoEqual(t, page1.EndCursor, (*string)(nil))
 
 		page2, err := asUser.Aggregators(ctx, project.ID, types.AggregatorsParams{
-			Last:   ptrUint64(3),
+			Last:   ptrUint(3),
 			Before: page1.EndCursor,
 		})
 		wantEqual(t, err, nil)
@@ -174,20 +174,20 @@ func TestClient_Aggregators(t *testing.T) {
 
 		envOneAggregators, err := asUser.Aggregators(ctx, project.ID, types.AggregatorsParams{
 			EnvironmentID: ptrStr(envOne.ID),
-			Last:          ptrUint64(0),
+			Last:          ptrUint(0),
 		})
 		wantEqual(t, err, nil)
 		wantEqual(t, len(envOneAggregators.Items), 1)
 
 		envTwoAggregators, err := asUser.Aggregators(ctx, project.ID, types.AggregatorsParams{
 			EnvironmentID: ptrStr(envTwo.ID),
-			Last:          ptrUint64(0),
+			Last:          ptrUint(0),
 		})
 		wantEqual(t, err, nil)
 		wantEqual(t, len(envTwoAggregators.Items), 1)
 
 		bothEnvsAggregators, err := asUser.Aggregators(ctx, project.ID, types.AggregatorsParams{
-			Last: ptrUint64(0),
+			Last: ptrUint(0),
 		})
 		wantEqual(t, err, nil)
 		wantNoEqual(t, len(bothEnvsAggregators.Items), 1)
@@ -212,7 +212,7 @@ func TestClient_Aggregator(t *testing.T) {
 	wantEqual(t, got.Name, created.Name)
 	wantEqual(t, got.Version, created.Version)
 	wantEqual(t, got.Token, created.Token)
-	wantEqual(t, got.PipelinesCount, uint64(1))
+	wantEqual(t, got.PipelinesCount, uint(1))
 	wantEqual(t, got.CreatedAt, created.CreatedAt)
 	wantEqual(t, got.UpdatedAt, created.CreatedAt)
 	wantEqual(t, got.Status, types.AggregatorStatusWaiting)

--- a/client/environment.go
+++ b/client/environment.go
@@ -19,7 +19,7 @@ func (c *Client) CreateEnvironment(ctx context.Context, projectID string, payloa
 func (c *Client) Environments(ctx context.Context, projectID string, params types.EnvironmentsParams) (types.Environments, error) {
 	q := url.Values{}
 	if params.Last != nil {
-		q.Set("last", strconv.FormatUint(*params.Last, uintBase))
+		q.Set("last", strconv.FormatUint(uint64(*params.Last), uintBase))
 	}
 	if params.Before != nil {
 		q.Set("before", *params.Before)

--- a/client/environment_test.go
+++ b/client/environment_test.go
@@ -74,14 +74,14 @@ func TestClient_Environments(t *testing.T) {
 		}
 
 		page1, err := asUser.Environments(ctx, project.ID, types.EnvironmentsParams{
-			Last: ptrUint64(3),
+			Last: ptrUint(3),
 		})
 		wantEqual(t, err, nil)
 		wantEqual(t, len(page1.Items), 3)
 		wantNoEqual(t, page1.EndCursor, (*string)(nil))
 
 		page2, err := asUser.Environments(ctx, project.ID, types.EnvironmentsParams{
-			Last:   ptrUint64(3),
+			Last:   ptrUint(3),
 			Before: page1.EndCursor,
 		})
 		wantEqual(t, err, nil)

--- a/client/membership.go
+++ b/client/membership.go
@@ -13,7 +13,7 @@ import (
 func (c *Client) Members(ctx context.Context, projectID string, params types.MembersParams) (types.Memberships, error) {
 	q := url.Values{}
 	if params.Last != nil {
-		q.Set("last", strconv.FormatUint(*params.Last, uintBase))
+		q.Set("last", strconv.FormatUint(uint64(*params.Last), uintBase))
 	}
 	if params.Before != nil {
 		q.Set("before", *params.Before)

--- a/client/metric_test.go
+++ b/client/metric_test.go
@@ -2,6 +2,7 @@ package client_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -17,6 +18,11 @@ func TestClient_AggregatorPipelinesMetrics(t *testing.T) {
 	token := defaultToken(t, asUser)
 
 	coreInstance, err := setupCoreInstance(dockerPool, asUser.BaseURL, token)
+	if errors.Is(err, errNoKubeConfig) {
+		t.SkipNow()
+		return
+	}
+
 	wantEqual(t, err, nil)
 	t.Cleanup(func() {
 		_ = coreInstance.Close()

--- a/client/pipeline.go
+++ b/client/pipeline.go
@@ -22,7 +22,7 @@ func (c *Client) CreatePipeline(ctx context.Context, aggregatorID string, payloa
 func (c *Client) Pipelines(ctx context.Context, aggregatorID string, params types.PipelinesParams) (types.Pipelines, error) {
 	q := url.Values{}
 	if params.Last != nil {
-		q.Set("last", strconv.FormatUint(*params.Last, uintBase))
+		q.Set("last", strconv.FormatUint(uint64(*params.Last), uintBase))
 	}
 	if params.Before != nil {
 		q.Set("before", *params.Before)
@@ -46,7 +46,7 @@ func (c *Client) Pipelines(ctx context.Context, aggregatorID string, params type
 func (c *Client) ProjectPipelines(ctx context.Context, projectID string, params types.PipelinesParams) (types.Pipelines, error) {
 	q := url.Values{}
 	if params.Last != nil {
-		q.Set("last", strconv.FormatUint(*params.Last, uintBase))
+		q.Set("last", strconv.FormatUint(uint64(*params.Last), uintBase))
 	}
 	if params.Before != nil {
 		q.Set("before", *params.Before)

--- a/client/pipeline_config.go
+++ b/client/pipeline_config.go
@@ -14,7 +14,7 @@ import (
 func (c *Client) PipelineConfigHistory(ctx context.Context, pipelineID string, params types.PipelineConfigHistoryParams) (types.PipelineConfigHistory, error) {
 	q := url.Values{}
 	if params.Last != nil {
-		q.Set("last", strconv.FormatUint(*params.Last, uintBase))
+		q.Set("last", strconv.FormatUint(uint64(*params.Last), uintBase))
 	}
 	if params.Before != nil {
 		q.Set("before", *params.Before)

--- a/client/pipeline_config_test.go
+++ b/client/pipeline_config_test.go
@@ -45,9 +45,9 @@ func TestClient_PipelineConfigHistory(t *testing.T) {
 		}
 		allConfigs, err := asUser.PipelineConfigHistory(ctx, pipeline.ID, types.PipelineConfigHistoryParams{})
 		wantEqual(t, err, nil)
-		page1, err := asUser.PipelineConfigHistory(ctx, pipeline.ID, types.PipelineConfigHistoryParams{Last: ptrUint64(3)})
+		page1, err := asUser.PipelineConfigHistory(ctx, pipeline.ID, types.PipelineConfigHistoryParams{Last: ptrUint(3)})
 		wantEqual(t, err, nil)
-		page2, err := asUser.PipelineConfigHistory(ctx, pipeline.ID, types.PipelineConfigHistoryParams{Last: ptrUint64(3), Before: page1.EndCursor})
+		page2, err := asUser.PipelineConfigHistory(ctx, pipeline.ID, types.PipelineConfigHistoryParams{Last: ptrUint(3), Before: page1.EndCursor})
 		wantEqual(t, err, nil)
 
 		want := allConfigs.Items[3:6]

--- a/client/pipeline_file.go
+++ b/client/pipeline_file.go
@@ -23,7 +23,7 @@ func (c *Client) CreatePipelineFile(ctx context.Context, pipelineID string, payl
 func (c *Client) PipelineFiles(ctx context.Context, pipelineID string, params types.PipelineFilesParams) (types.PipelineFiles, error) {
 	q := url.Values{}
 	if params.Last != nil {
-		q.Set("last", strconv.FormatUint(*params.Last, uintBase))
+		q.Set("last", strconv.FormatUint(uint64(*params.Last), uintBase))
 	}
 	if params.Before != nil {
 		q.Set("before", *params.Before)

--- a/client/pipeline_file_test.go
+++ b/client/pipeline_file_test.go
@@ -65,9 +65,9 @@ func TestClient_PipelineFiles(t *testing.T) {
 
 		allPipelineFiles, err := asUser.PipelineFiles(ctx, pipeline.ID, types.PipelineFilesParams{})
 		wantEqual(t, err, nil)
-		page1, err := asUser.PipelineFiles(ctx, pipeline.ID, types.PipelineFilesParams{Last: ptrUint64(3)})
+		page1, err := asUser.PipelineFiles(ctx, pipeline.ID, types.PipelineFilesParams{Last: ptrUint(3)})
 		wantEqual(t, err, nil)
-		page2, err := asUser.PipelineFiles(ctx, pipeline.ID, types.PipelineFilesParams{Last: ptrUint64(3), Before: page1.EndCursor})
+		page2, err := asUser.PipelineFiles(ctx, pipeline.ID, types.PipelineFilesParams{Last: ptrUint(3), Before: page1.EndCursor})
 		wantEqual(t, err, nil)
 
 		want := allPipelineFiles.Items[3:6]

--- a/client/pipeline_port.go
+++ b/client/pipeline_port.go
@@ -21,7 +21,7 @@ func (c *Client) CreatePipelinePort(ctx context.Context, pipelineID string, payl
 func (c *Client) PipelinePorts(ctx context.Context, pipelineID string, params types.PipelinePortsParams) (types.PipelinePorts, error) {
 	q := url.Values{}
 	if params.Last != nil {
-		q.Set("last", strconv.FormatUint(*params.Last, uintBase))
+		q.Set("last", strconv.FormatUint(uint64(*params.Last), uintBase))
 	}
 	if params.Before != nil {
 		q.Set("before", *params.Before)

--- a/client/pipeline_port_test.go
+++ b/client/pipeline_port_test.go
@@ -77,9 +77,9 @@ func TestClient_PipelinePorts(t *testing.T) {
 		}
 		allPorts, err := asUser.PipelinePorts(ctx, pipeline.ID, types.PipelinePortsParams{})
 		wantEqual(t, err, nil)
-		page1, err := asUser.PipelinePorts(ctx, pipeline.ID, types.PipelinePortsParams{Last: ptrUint64(3)})
+		page1, err := asUser.PipelinePorts(ctx, pipeline.ID, types.PipelinePortsParams{Last: ptrUint(3)})
 		wantEqual(t, err, nil)
-		page2, err := asUser.PipelinePorts(ctx, pipeline.ID, types.PipelinePortsParams{Last: ptrUint64(3), Before: page1.EndCursor})
+		page2, err := asUser.PipelinePorts(ctx, pipeline.ID, types.PipelinePortsParams{Last: ptrUint(3), Before: page1.EndCursor})
 		wantEqual(t, err, nil)
 
 		want := allPorts.Items[3:6]

--- a/client/pipeline_secret.go
+++ b/client/pipeline_secret.go
@@ -24,7 +24,7 @@ func (c *Client) CreatePipelineSecret(ctx context.Context, pipelineID string, pa
 func (c *Client) PipelineSecrets(ctx context.Context, pipelineID string, params types.PipelineSecretsParams) (types.PipelineSecrets, error) {
 	q := url.Values{}
 	if params.Last != nil {
-		q.Set("last", strconv.FormatUint(*params.Last, uintBase))
+		q.Set("last", strconv.FormatUint(uint64(*params.Last), uintBase))
 	}
 	if params.Before != nil {
 		q.Set("before", *params.Before)

--- a/client/pipeline_secret_test.go
+++ b/client/pipeline_secret_test.go
@@ -64,9 +64,9 @@ func TestClient_PipelineSecrets(t *testing.T) {
 		}
 		allSecrets, err := asUser.PipelineSecrets(ctx, pipeline.ID, types.PipelineSecretsParams{})
 		wantEqual(t, err, nil)
-		page1, err := asUser.PipelineSecrets(ctx, pipeline.ID, types.PipelineSecretsParams{Last: ptrUint64(3)})
+		page1, err := asUser.PipelineSecrets(ctx, pipeline.ID, types.PipelineSecretsParams{Last: ptrUint(3)})
 		wantEqual(t, err, nil)
-		page2, err := asUser.PipelineSecrets(ctx, pipeline.ID, types.PipelineSecretsParams{Last: ptrUint64(3), Before: page1.EndCursor})
+		page2, err := asUser.PipelineSecrets(ctx, pipeline.ID, types.PipelineSecretsParams{Last: ptrUint(3), Before: page1.EndCursor})
 		wantEqual(t, err, nil)
 
 		want := allSecrets.Items[3:6]

--- a/client/pipeline_status.go
+++ b/client/pipeline_status.go
@@ -14,7 +14,7 @@ import (
 func (c *Client) PipelineStatusHistory(ctx context.Context, pipelineID string, params types.PipelineStatusHistoryParams) (types.PipelineStatusHistory, error) {
 	q := url.Values{}
 	if params.Last != nil {
-		q.Set("last", strconv.FormatUint(*params.Last, uintBase))
+		q.Set("last", strconv.FormatUint(uint64(*params.Last), uintBase))
 	}
 	if params.Before != nil {
 		q.Set("before", *params.Before)

--- a/client/pipeline_status_test.go
+++ b/client/pipeline_status_test.go
@@ -54,9 +54,9 @@ func TestClient_PipelineStatusHistory(t *testing.T) {
 		}
 		allStatusHistory, err := asUser.PipelineStatusHistory(ctx, pipeline.ID, types.PipelineStatusHistoryParams{})
 		wantEqual(t, err, nil)
-		page1, err := asUser.PipelineStatusHistory(ctx, pipeline.ID, types.PipelineStatusHistoryParams{Last: ptrUint64(3)})
+		page1, err := asUser.PipelineStatusHistory(ctx, pipeline.ID, types.PipelineStatusHistoryParams{Last: ptrUint(3)})
 		wantEqual(t, err, nil)
-		page2, err := asUser.PipelineStatusHistory(ctx, pipeline.ID, types.PipelineStatusHistoryParams{Last: ptrUint64(3), Before: page1.EndCursor})
+		page2, err := asUser.PipelineStatusHistory(ctx, pipeline.ID, types.PipelineStatusHistoryParams{Last: ptrUint(3), Before: page1.EndCursor})
 		wantEqual(t, err, nil)
 
 		want := allStatusHistory.Items[3:6]

--- a/client/pipeline_test.go
+++ b/client/pipeline_test.go
@@ -107,7 +107,7 @@ func TestClient_CreatePipeline(t *testing.T) {
 	wantNoTimeZero(t, got.ResourceProfile.CreatedAt)
 	wantNoTimeZero(t, got.ResourceProfile.UpdatedAt)
 
-	wantEqual(t, got.ReplicasCount, uint64(3))
+	wantEqual(t, got.ReplicasCount, uint(3))
 	wantNoTimeZero(t, got.CreatedAt)
 }
 
@@ -188,14 +188,14 @@ func TestClient_Pipelines(t *testing.T) {
 		}
 
 		page1, err := asUser.Pipelines(ctx, aggregator.ID, types.PipelinesParams{
-			Last: ptrUint64(3),
+			Last: ptrUint(3),
 		})
 		wantEqual(t, err, nil)
 		wantEqual(t, len(page1.Items), 3)
 		wantNoEqual(t, page1.EndCursor, (*string)(nil))
 
 		page2, err := asUser.Pipelines(ctx, aggregator.ID, types.PipelinesParams{
-			Last:   ptrUint64(3),
+			Last:   ptrUint(3),
 			Before: page1.EndCursor,
 		})
 		wantEqual(t, err, nil)
@@ -318,14 +318,14 @@ func TestClient_ProjectPipelines(t *testing.T) {
 		}
 
 		page1, err := asUser.Pipelines(ctx, aggregator.ID, types.PipelinesParams{
-			Last: ptrUint64(3),
+			Last: ptrUint(3),
 		})
 		wantEqual(t, err, nil)
 		wantEqual(t, len(page1.Items), 3)
 		wantNoEqual(t, page1.EndCursor, (*string)(nil))
 
 		page2, err := asUser.Pipelines(ctx, aggregator.ID, types.PipelinesParams{
-			Last:   ptrUint64(3),
+			Last:   ptrUint(3),
 			Before: page1.EndCursor,
 		})
 		wantEqual(t, err, nil)
@@ -475,7 +475,7 @@ func TestClient_UpdatePipeline(t *testing.T) {
 
 	got, err := asUser.UpdatePipeline(ctx, pipeline.ID, types.UpdatePipeline{
 		Name:          ptrStr("test-pipeline-updated"),
-		ReplicasCount: ptrUint64(4),
+		ReplicasCount: ptrUint(4),
 		RawConfig:     ptrStr(testFbitConfigWithAddr3),
 		Secrets: []types.UpdatePipelineSecret{
 			{

--- a/client/project.go
+++ b/client/project.go
@@ -22,7 +22,7 @@ func (c *Client) CreateProject(ctx context.Context, payload types.CreateProject)
 func (c *Client) Projects(ctx context.Context, params types.ProjectsParams) (types.Projects, error) {
 	q := url.Values{}
 	if params.Last != nil {
-		q.Set("last", strconv.FormatUint(*params.Last, uintBase))
+		q.Set("last", strconv.FormatUint(uint64(*params.Last), uintBase))
 	}
 	if params.Before != nil {
 		q.Set("before", *params.Before)

--- a/client/project_test.go
+++ b/client/project_test.go
@@ -34,7 +34,7 @@ func TestClient_Projects(t *testing.T) {
 		wantEqual(t, len(got.Items), 1) // a default project must be created for the user as a side effect.
 		wantNoEqual(t, got.Items[0].ID, "")
 		wantEqual(t, got.Items[0].Name, "default")
-		wantEqual(t, got.Items[0].MembersCount, uint64(1))
+		wantEqual(t, got.Items[0].MembersCount, uint(1))
 		wantNoTimeZero(t, got.Items[0].CreatedAt)
 		wantNoEqual(t, got.Items[0].Membership, nil)
 		wantNoEqual(t, got.Items[0].Membership.ID, "")
@@ -50,9 +50,9 @@ func TestClient_Projects(t *testing.T) {
 		}
 		allProjects, err := asUser.Projects(ctx, types.ProjectsParams{})
 		wantEqual(t, err, nil)
-		page1, err := asUser.Projects(ctx, types.ProjectsParams{Last: ptrUint64(3)})
+		page1, err := asUser.Projects(ctx, types.ProjectsParams{Last: ptrUint(3)})
 		wantEqual(t, err, nil)
-		page2, err := asUser.Projects(ctx, types.ProjectsParams{Last: ptrUint64(3), Before: page1.EndCursor})
+		page2, err := asUser.Projects(ctx, types.ProjectsParams{Last: ptrUint(3), Before: page1.EndCursor})
 		wantEqual(t, err, nil)
 
 		want := allProjects.Items[3:6]
@@ -70,7 +70,7 @@ func TestClient_Project(t *testing.T) {
 	wantEqual(t, err, nil)
 	wantEqual(t, got.ID, project.ID)
 	wantEqual(t, got.Name, "default")
-	wantEqual(t, got.MembersCount, uint64(1))
+	wantEqual(t, got.MembersCount, uint(1))
 	wantEqual(t, got.CreatedAt, project.CreatedAt)
 	wantNoEqual(t, got.Membership, nil)
 	wantEqual(t, *got.Membership, *project.Membership)

--- a/client/resource_profile.go
+++ b/client/resource_profile.go
@@ -25,7 +25,7 @@ func (c *Client) CreateResourceProfile(ctx context.Context, aggregatorID string,
 func (c *Client) ResourceProfiles(ctx context.Context, aggregatorID string, params types.ResourceProfilesParams) (types.ResourceProfiles, error) {
 	q := url.Values{}
 	if params.Last != nil {
-		q.Set("last", strconv.FormatUint(*params.Last, uintBase))
+		q.Set("last", strconv.FormatUint(uint64(*params.Last), uintBase))
 	}
 	if params.Before != nil {
 		q.Set("before", *params.Before)

--- a/client/resource_profile_test.go
+++ b/client/resource_profile_test.go
@@ -87,9 +87,9 @@ func TestClient_ResourceProfiles(t *testing.T) {
 		}
 		allResourceProfile, err := asUser.ResourceProfiles(ctx, aggregator.ID, types.ResourceProfilesParams{})
 		wantEqual(t, err, nil)
-		page1, err := asUser.ResourceProfiles(ctx, aggregator.ID, types.ResourceProfilesParams{Last: ptrUint64(3)})
+		page1, err := asUser.ResourceProfiles(ctx, aggregator.ID, types.ResourceProfilesParams{Last: ptrUint(3)})
 		wantEqual(t, err, nil)
-		page2, err := asUser.ResourceProfiles(ctx, aggregator.ID, types.ResourceProfilesParams{Last: ptrUint64(3), Before: page1.EndCursor})
+		page2, err := asUser.ResourceProfiles(ctx, aggregator.ID, types.ResourceProfilesParams{Last: ptrUint(3), Before: page1.EndCursor})
 		wantEqual(t, err, nil)
 
 		want := allResourceProfile.Items[3:6]

--- a/client/token.go
+++ b/client/token.go
@@ -24,7 +24,7 @@ func (c *Client) CreateToken(ctx context.Context, projectID string, payload type
 func (c *Client) Tokens(ctx context.Context, projectID string, params types.TokensParams) (types.Tokens, error) {
 	q := url.Values{}
 	if params.Last != nil {
-		q.Set("last", strconv.FormatUint(*params.Last, uintBase))
+		q.Set("last", strconv.FormatUint(uint64(*params.Last), uintBase))
 	}
 	if params.Before != nil {
 		q.Set("before", *params.Before)

--- a/client/token_test.go
+++ b/client/token_test.go
@@ -54,9 +54,9 @@ func TestClient_Tokens(t *testing.T) {
 
 		allTokens, err := asUser.Tokens(ctx, project.ID, types.TokensParams{})
 		wantEqual(t, err, nil)
-		page1, err := asUser.Tokens(ctx, project.ID, types.TokensParams{Last: ptrUint64(3)})
+		page1, err := asUser.Tokens(ctx, project.ID, types.TokensParams{Last: ptrUint(3)})
 		wantEqual(t, err, nil)
-		page2, err := asUser.Tokens(ctx, project.ID, types.TokensParams{Last: ptrUint64(3), Before: page1.EndCursor})
+		page2, err := asUser.Tokens(ctx, project.ID, types.TokensParams{Last: ptrUint(3), Before: page1.EndCursor})
 		wantEqual(t, err, nil)
 
 		want := allTokens.Items[3:6]

--- a/client/trace.go
+++ b/client/trace.go
@@ -25,7 +25,7 @@ func (c *Client) CreateTraceSession(ctx context.Context, pipelineID string, in t
 func (c *Client) TraceSessions(ctx context.Context, pipelineID string, params types.TraceSessionsParams) (types.TraceSessions, error) {
 	q := url.Values{}
 	if params.Last != nil {
-		q.Set("last", strconv.FormatUint(*params.Last, uintBase))
+		q.Set("last", strconv.FormatUint(uint64(*params.Last), uintBase))
 	}
 	if params.Before != nil {
 		q.Set("before", *params.Before)
@@ -74,7 +74,7 @@ func (c *Client) CreateTraceRecord(ctx context.Context, pipelineID string, in ty
 func (c *Client) TraceRecords(ctx context.Context, sessionID string, params types.TraceRecordsParams) (types.TraceRecords, error) {
 	q := url.Values{}
 	if params.Last != nil {
-		q.Set("last", strconv.FormatUint(*params.Last, uintBase))
+		q.Set("last", strconv.FormatUint(uint64(*params.Last), uintBase))
 	}
 	if params.Before != nil {
 		q.Set("before", *params.Before)

--- a/spec/open-api.yml
+++ b/spec/open-api.yml
@@ -1765,7 +1765,6 @@ components:
           example: nest_2
         return_code:
           type: integer
-          format: int64
         records:
           type: array
           items:
@@ -3529,7 +3528,6 @@ paths:
   #                properties:
   #                  totalInserted:
   #                    type: integer
-  #                    format: int64
   #                    minimum: 0
   #                required:
   #                  - totalInserted

--- a/types/agent.go
+++ b/types/agent.go
@@ -22,7 +22,7 @@ type Agent struct {
 	Tags                []string         `json:"tags" yaml:"tags"`
 	FirstMetricsAddedAt time.Time        `json:"firstMetricsAddedAt" yaml:"firstMetricsAddedAt"`
 	LastMetricsAddedAt  time.Time        `json:"lastMetricsAddedAt" yaml:"lastMetricsAddedAt"`
-	MetricsCount        uint64           `json:"metricsCount" yaml:"metricsCount"`
+	MetricsCount        uint             `json:"metricsCount" yaml:"metricsCount"`
 	CreatedAt           time.Time        `json:"createdAt" yaml:"createdAt"`
 	UpdatedAt           time.Time        `json:"updatedAt" yaml:"updatedAt"`
 }
@@ -78,7 +78,7 @@ type RegisteredAgent struct {
 
 // AgentsParams request payload for querying agents.
 type AgentsParams struct {
-	Last          *uint64
+	Last          *uint
 	Before        *string
 	Name          *string
 	Tags          *string

--- a/types/agent_config.go
+++ b/types/agent_config.go
@@ -17,6 +17,6 @@ type AgentConfigHistory struct {
 
 // AgentConfigHistoryParams request payload for querying the agent config history.
 type AgentConfigHistoryParams struct {
-	Last   *uint64
+	Last   *uint
 	Before *string
 }

--- a/types/aggregator.go
+++ b/types/aggregator.go
@@ -16,7 +16,7 @@ type Aggregator struct {
 	Name            string           `json:"name" yaml:"name"`
 	EnvironmentName string           `json:"environmentName" yaml:"environmentName"`
 	Version         string           `json:"version" yaml:"version"`
-	PipelinesCount  uint64           `json:"pipelinesCount" yaml:"pipelinesCount"`
+	PipelinesCount  uint             `json:"pipelinesCount" yaml:"pipelinesCount"`
 	Tags            []string         `json:"tags" yaml:"tags"`
 	Metadata        *json.RawMessage `json:"metadata" yaml:"metadata"`
 	Status          AggregatorStatus `json:"status" yaml:"status"`
@@ -126,7 +126,7 @@ type CreatedAggregator struct {
 
 // AggregatorsParams request payload for querying aggregators.
 type AggregatorsParams struct {
-	Last          *uint64
+	Last          *uint
 	Before        *string
 	Name          *string
 	Tags          *string

--- a/types/environment.go
+++ b/types/environment.go
@@ -26,7 +26,7 @@ type Environments struct {
 }
 
 type EnvironmentsParams struct {
-	Last   *uint64
+	Last   *uint
 	Before *string
 	Name   *string
 }

--- a/types/membership.go
+++ b/types/membership.go
@@ -29,6 +29,6 @@ const (
 
 // MembersParams request payload for querying members.
 type MembersParams struct {
-	Last   *uint64
+	Last   *uint
 	Before *string
 }

--- a/types/metric.go
+++ b/types/metric.go
@@ -141,7 +141,7 @@ type MetricsParams struct {
 
 // CreatedAgentMetrics response model for created agent metrics.
 type CreatedAgentMetrics struct {
-	Total uint64 `json:"totalInserted"`
+	Total uint `json:"totalInserted"`
 }
 
 // PipelinesMetrics response payload for aggregator level pipeline metrics.

--- a/types/pipeline.go
+++ b/types/pipeline.go
@@ -13,7 +13,7 @@ type Pipeline struct {
 	Status          PipelineStatus   `json:"status" yaml:"status"`
 	ResourceProfile ResourceProfile  `json:"resourceProfile" yaml:"resourceProfile"`
 	TracingEnabled  bool             `json:"tracingEnabled" yaml:"tracingEnabled"`
-	ReplicasCount   uint64           `json:"replicasCount" yaml:"replicasCount"`
+	ReplicasCount   uint             `json:"replicasCount" yaml:"replicasCount"`
 	Tags            []string         `json:"tags" yaml:"tags"`
 	Metadata        *json.RawMessage `json:"metadata" yaml:"metadata"`
 	CreatedAt       time.Time        `json:"createdAt" yaml:"createdAt"`
@@ -29,7 +29,7 @@ type Pipelines struct {
 // CreatePipeline request payload for creating a new pipeline.
 type CreatePipeline struct {
 	Name                      string                 `json:"name"`
-	ReplicasCount             uint64                 `json:"replicasCount"`
+	ReplicasCount             uint                   `json:"replicasCount"`
 	RawConfig                 string                 `json:"rawConfig"`
 	ConfigFormat              ConfigFormat           `json:"configFormat"`
 	Secrets                   []CreatePipelineSecret `json:"secrets"`
@@ -49,14 +49,14 @@ type CreatedPipeline struct {
 	Files           []PipelineFile   `json:"files"`
 	Status          PipelineStatus   `json:"status"`
 	ResourceProfile ResourceProfile  `json:"resourceProfile"`
-	ReplicasCount   uint64           `json:"replicasCount"`
+	ReplicasCount   uint             `json:"replicasCount"`
 	CreatedAt       time.Time        `json:"createdAt"`
 }
 
 // UpdatePipeline request payload for updating a pipeline.
 type UpdatePipeline struct {
 	Name                      *string                `json:"name"`
-	ReplicasCount             *uint64                `json:"replicasCount"`
+	ReplicasCount             *uint                  `json:"replicasCount"`
 	RawConfig                 *string                `json:"rawConfig"`
 	ConfigFormat              *ConfigFormat          `json:"configFormat"`
 	Secrets                   []UpdatePipelineSecret `json:"secrets"`
@@ -69,7 +69,7 @@ type UpdatePipeline struct {
 
 // PipelinesParams request payload for querying pipelines.
 type PipelinesParams struct {
-	Last         *uint64
+	Last         *uint
 	Before       *string
 	Name         *string
 	Tags         *string

--- a/types/pipeline_config.go
+++ b/types/pipeline_config.go
@@ -26,7 +26,7 @@ type PipelineConfigHistory struct {
 
 // PipelineConfigHistoryParams request payload for querying the pipeline config history.
 type PipelineConfigHistoryParams struct {
-	Last         *uint64
+	Last         *uint
 	Before       *string
 	ConfigFormat *ConfigFormat
 }

--- a/types/pipeline_file.go
+++ b/types/pipeline_file.go
@@ -33,7 +33,7 @@ type CreatedPipelineFile struct {
 
 // PipelineFilesParams request payload for querying the pipeline files.
 type PipelineFilesParams struct {
-	Last   *uint64
+	Last   *uint
 	Before *string
 }
 

--- a/types/pipeline_port.go
+++ b/types/pipeline_port.go
@@ -35,7 +35,7 @@ type CreatedPipelinePort struct {
 
 // PipelinePortsParams request payload for querying the pipeline ports.
 type PipelinePortsParams struct {
-	Last   *uint64
+	Last   *uint
 	Before *string
 }
 

--- a/types/pipeline_secret.go
+++ b/types/pipeline_secret.go
@@ -31,7 +31,7 @@ type CreatedPipelineSecret struct {
 
 // PipelineSecretsParams request payload for querying the pipeline secrets.
 type PipelineSecretsParams struct {
-	Last   *uint64
+	Last   *uint
 	Before *string
 }
 

--- a/types/pipeline_status.go
+++ b/types/pipeline_status.go
@@ -34,7 +34,7 @@ const (
 
 // PipelineStatusHistoryParams request payload for querying the pipeline status history.
 type PipelineStatusHistoryParams struct {
-	Last         *uint64
+	Last         *uint
 	Before       *string
 	Status       *PipelineStatusKind
 	ConfigFormat *ConfigFormat

--- a/types/project.go
+++ b/types/project.go
@@ -6,9 +6,9 @@ import "time"
 type Project struct {
 	ID               string    `json:"id" yaml:"id"`
 	Name             string    `json:"name" yaml:"name"`
-	MembersCount     uint64    `json:"membersCount" yaml:"membersCount"`
-	AgentsCount      uint64    `json:"agentsCount" yaml:"agentsCount"`
-	AggregatorsCount uint64    `json:"aggregatorsCount" yaml:"aggregatorsCount"`
+	MembersCount     uint      `json:"membersCount" yaml:"membersCount"`
+	AgentsCount      uint      `json:"agentsCount" yaml:"agentsCount"`
+	AggregatorsCount uint      `json:"aggregatorsCount" yaml:"aggregatorsCount"`
 	CreatedAt        time.Time `json:"createdAt" yaml:"createdAt"`
 
 	Membership *Membership `json:"membership" yaml:"membership"`
@@ -35,7 +35,7 @@ type CreatedProject struct {
 
 // ProjectsParams request payload for querying projects.
 type ProjectsParams struct {
-	Last   *uint64
+	Last   *uint
 	Before *string
 	Name   *string
 }

--- a/types/resource_profile.go
+++ b/types/resource_profile.go
@@ -61,7 +61,7 @@ type CreatedResourceProfile struct {
 
 // ResourceProfilesParams request payload for querying resource profiles.
 type ResourceProfilesParams struct {
-	Last   *uint64
+	Last   *uint
 	Before *string
 }
 

--- a/types/token.go
+++ b/types/token.go
@@ -23,7 +23,7 @@ type CreateToken struct {
 
 // TokensParams request payload for querying tokens.
 type TokensParams struct {
-	Last   *uint64
+	Last   *uint
 	Before *string
 	Name   *string
 }

--- a/types/trace.go
+++ b/types/trace.go
@@ -42,7 +42,7 @@ type CreatedTraceSession struct {
 
 // TraceSessionsParams request payload for querying trace sessions.
 type TraceSessionsParams struct {
-	Last   *uint64
+	Last   *uint
 	Before *string
 }
 
@@ -143,7 +143,7 @@ type CreatedTraceRecord struct {
 
 // TraceRecordsParams request payload for querying trace records.
 type TraceRecordsParams struct {
-	Last   *uint64
+	Last   *uint
 	Before *string
 }
 


### PR DESCRIPTION
Following https://github.com/calyptia/api/pull/128
To use plain int instead of int64 were possible. This is to avoid issues with javascript clients that don't support int64 (JSON).