### PR TITLE
types: add plugin info to endpoints

### DIFF
--- a/types/pipeline_port.go
+++ b/types/pipeline_port.go
@@ -9,14 +9,17 @@ type PipelinePort struct {
 	FrontendPort uint      `json:"frontendPort" yaml:"frontendPort"`
 	BackendPort  uint      `json:"backendPort" yaml:"backendPort"`
 	Endpoint     string    `json:"endpoint" yaml:"endpoint"`
+	PluginID     *string   `json:"pluginID" yaml:"pluginID"`
+	PluginName   *string   `json:"pluginName" yaml:"pluginName"`
+	PluginAlias  *string   `json:"pluginAlias" yaml:"pluginAlias"`
 	CreatedAt    time.Time `json:"createdAt" yaml:"createdAt"`
 	UpdatedAt    time.Time `json:"updatedAt" yaml:"updatedAt"`
 }
 
 // PipelinePorts paginated list.
 type PipelinePorts struct {
-	Items     []PipelinePort
-	EndCursor *string
+	Items     []PipelinePort `json:"items" yaml:"items"`
+	EndCursor *string        `json:"endCursor" yaml:"endCursor"`
 }
 
 // CreatePipelinePort request payload for creating a pipeline port.
@@ -29,8 +32,11 @@ type CreatePipelinePort struct {
 
 // CreatedPipelinePort response payload after creating a pipeline port successfully.
 type CreatedPipelinePort struct {
-	ID        string    `json:"id"`
-	CreatedAt time.Time `json:"createdAt"`
+	ID          string    `json:"id"`
+	PluginID    *string   `json:"pluginID" yaml:"pluginID"`
+	PluginName  *string   `json:"pluginName" yaml:"pluginName"`
+	PluginAlias *string   `json:"pluginAlias" yaml:"pluginAlias"`
+	CreatedAt   time.Time `json:"createdAt"`
 }
 
 // PipelinePortsParams request payload for querying the pipeline ports.


### PR DESCRIPTION
Adding the plugin info to the endpoints.

*This time working on reading them back.*
*As always, spec, client and tests will come in a separate PR.*