### PR TITLE
Add PipelineStatusScaling and remove PipelineStatusDeleted.

### DIFF
--- a/client/pipeline_status_test.go
+++ b/client/pipeline_status_test.go
@@ -62,4 +62,21 @@ func TestClient_PipelineStatusHistory(t *testing.T) {
 		want := allStatusHistory.Items[3:6]
 		wantEqual(t, page2.Items, want)
 	})
+
+	t.Run("pipeline statuses", func(t *testing.T) {
+		statuses := []types.PipelineStatusKind{
+			types.PipelineStatusFailed,
+			types.PipelineStatusStarted,
+			types.PipelineStatusStarting,
+			types.PipelineStatusNew,
+			types.PipelineStatusScaling,
+		}
+
+		for _, status := range statuses {
+			_, err := withToken.UpdatePipeline(ctx, pipeline.ID, types.UpdatePipeline{
+				Status: (*types.PipelineStatusKind)(ptrStr(string(status))),
+			})
+			wantEqual(t, err, nil)
+		}
+	})
 }

--- a/spec/open-api.yml
+++ b/spec/open-api.yml
@@ -496,7 +496,7 @@ components:
             - FAILED
             - STARTING
             - STARTED
-            - DELETED
+            - SCALING
         createdAt:
           type: string
           format: date-time

--- a/types/pipeline_status.go
+++ b/types/pipeline_status.go
@@ -28,8 +28,8 @@ const (
 	PipelineStatusStarting PipelineStatusKind = "STARTING"
 	// PipelineStatusStarted is the status of a started pipeline.
 	PipelineStatusStarted PipelineStatusKind = "STARTED"
-	// PipelineStatusDeleted is the status of a deleted pipeline.
-	PipelineStatusDeleted PipelineStatusKind = "DELETED"
+	// PipelineStatusScaling is the status of a pipeline while scaling up/down.
+	PipelineStatusScaling PipelineStatusKind = "SCALING"
 )
 
 // PipelineStatusHistoryParams request payload for querying the pipeline status history.


### PR DESCRIPTION
- Deleted isn't a valid status anymore.
- Scaling should be reported independently.

Signed-off-by: Jorge Niedbalski <j@calyptia.com>
