### PR TITLE
spec: update instance tags

### DIFF
--- a/client/aggregator_test.go
+++ b/client/aggregator_test.go
@@ -231,7 +231,7 @@ func TestClient_UpdateAggregator(t *testing.T) {
 
 	err = withToken.UpdateAggregator(ctx, created.ID, types.UpdateAggregator{
 		Name: ptrStr("test-aggregator-updated"),
-		Tags: ptrSliceStr([]string{"updated-tag"}),
+		Tags: ptrSliceStr([]string{"updatedtag"}),
 	})
 	wantEqual(t, err, nil)
 

--- a/client/aggregator_test.go
+++ b/client/aggregator_test.go
@@ -230,30 +230,19 @@ func TestClient_UpdateAggregator(t *testing.T) {
 	wantEqual(t, err, nil)
 
 	err = withToken.UpdateAggregator(ctx, created.ID, types.UpdateAggregator{
-		Name: ptrStr("test-aggregator-updated"),
-		Tags: ptrSliceStr([]string{"updatedtag"}),
+		Name:     ptrStr("updated-core-instance"),
+		Version:  ptrStr("v1.0.0"),
+		Tags:     ptrSliceStr([]string{"updatedtag"}),
+		Metadata: ptrJSON(json.RawMessage(`{"k8s.cluster_name":"test"}`)),
 	})
 	wantEqual(t, err, nil)
 
-	t.Run("version", func(t *testing.T) {
-		err = withToken.UpdateAggregator(ctx, created.ID, types.UpdateAggregator{
-			Version: ptrStr(types.DefaultAggregatorVersion),
-		})
-
-		wantEqual(t, err, nil)
-
-		err = withToken.UpdateAggregator(ctx, created.ID, types.UpdateAggregator{
-			Version: ptrStr("non-semver-version"),
-		})
-
-		wantErrMsg(t, err, "invalid aggregator version")
-
-		err = withToken.UpdateAggregator(ctx, created.ID, types.UpdateAggregator{
-			Version: ptrStr(""),
-		})
-
-		wantErrMsg(t, err, "invalid aggregator version")
-	})
+	found, err := asUser.Aggregator(ctx, created.ID)
+	wantEqual(t, err, nil)
+	wantEqual(t, found.Name, "updated-core-instance")
+	wantEqual(t, found.Version, "v1.0.0")
+	wantEqual(t, found.Tags, []string{"updatedtag"})
+	wantEqual(t, *found.Metadata, json.RawMessage(`{"k8s.cluster_name":"test"}`))
 }
 
 func TestClient_DeleteAggregator(t *testing.T) {

--- a/client/aggregator_test.go
+++ b/client/aggregator_test.go
@@ -231,6 +231,7 @@ func TestClient_UpdateAggregator(t *testing.T) {
 
 	err = withToken.UpdateAggregator(ctx, created.ID, types.UpdateAggregator{
 		Name: ptrStr("test-aggregator-updated"),
+		Tags: ptrSliceStr([]string{"updated-tag"}),
 	})
 	wantEqual(t, err, nil)
 

--- a/client/client.go
+++ b/client/client.go
@@ -125,7 +125,7 @@ func (c *Client) do(ctx context.Context, method, path string, v, dest interface{
 		e := &types.Error{}
 		err = json.NewDecoder(resp.Body).Decode(&e)
 		if err != nil {
-			return fmt.Errorf("could not json decode error response: %w", err)
+			return fmt.Errorf("could not json decode error response: status_code=%d: %w", resp.StatusCode, err)
 		}
 
 		return e

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -731,6 +731,10 @@ func ptrBytes(b []byte) *[]byte {
 	return &b
 }
 
+func ptrJSON(b json.RawMessage) *json.RawMessage {
+	return &b
+}
+
 func randUUID(t *testing.T) string {
 	t.Helper()
 	return uuid.Must(uuid.NewRandom()).String()

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -715,6 +715,10 @@ func ptrStr(s string) *string {
 	return &s
 }
 
+func ptrSliceStr(ss []string) *[]string {
+	return &ss
+}
+
 func ptrBool(b bool) *bool {
 	return &b
 }

--- a/spec/open-api.yml
+++ b/spec/open-api.yml
@@ -1050,6 +1050,11 @@ components:
           type: string
           example: v0.1.12
           nullable: true
+        tags:
+          type: array
+          nullable: true
+          items:
+            type: string
         metadata:
           type: object
           nullable: true


### PR DESCRIPTION
Update the OpenAPI spec to add support for updating tags on a core instance.