### PR TITLE
Update FluentBitLog type

### DIFF
--- a/types/log.go
+++ b/types/log.go
@@ -11,8 +11,8 @@ import (
 // Where timestamp is a float with seconds and nanoseconds as fraction.
 // And attrs being an object with string key and values.
 type FluentBitLog struct {
-	Timestamp FluentBitTime
-	Attrs     FluentBitLogAttrs
+	Timestamp FluentBitTime     `json:"timestamp"`
+	Attrs     FluentBitLogAttrs `json:"record"`
 }
 
 // FluentBitTime wrapper.


### PR DESCRIPTION
After completing https://github.com/calyptia/cloud-lua-sandbox/issues/11, the sandbox API now receives objects in the format `{tag, timestamp, record}`.

Not sure if this is the correct way to go about this (is there a way to decouple json serialization from the type?), but in order to update the go-lua-sandbox-client, I need `FluentBitLog` type to serialize matching the new API.
