### PR TITLE
ci: Upgrade GitHub Actions to Node 22+ runtimes [sc-178410]

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,8 +8,7 @@ jobs:
     name: PR - MarkdownLint
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Run Markdown lint
         uses: actionshub/markdownlint@v3.1.4
 
@@ -18,8 +17,7 @@ jobs:
     name: PR - ActionLint
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Run Action lint
         run: |
           echo "::add-matcher::.github/actionlint-matcher.json"
@@ -32,7 +30,6 @@ jobs:
     name: PR - Shellcheck
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: PR - Shellcheck
         uses: ludeeus/action-shellcheck@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,9 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "^1.22"
 


### PR DESCRIPTION
## Summary
- Upgrades all JS-based GitHub Actions from Node 20 (or older) to Node 22+ versions
- SHA-pins all upgraded action references for supply-chain security
- Replaces `jwalton/gh-docker-logs@v2` with native `docker logs` (no Node 22+ release available)
- Addresses upcoming [Node 20 deprecation](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)

See also: [#332](https://github.com/chronosphereio/calyptia-api/pull/332) — bumps Go version in release workflow from 1.22 to 1.26.3

[sc-178410](https://app.shortcut.com/chronosphere/story/178410)

## Test plan
- [ ] CI passes on this branch
- [ ] Verify workflow behavior unchanged
- [ ] Verify docker logs are still captured in CI output

🤖 Generated with [Claude Code](https://claude.com/claude-code)