### PR TITLE
ci: Bump Go version in release workflow to 1.26.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup
         uses: actions/setup-go@v5
         with:
-          go-version: "^1.22"
+          go-version: "^1.26.3"
 
       - name: Release
         uses: goreleaser/goreleaser-action@v6


### PR DESCRIPTION
## Summary
- Bumps `go-version` from `^1.22` (EOL August 2024) to `^1.26.3` in release workflow
- Aligns with the Go version used across the rest of the org
- No `go.mod` in this repo so `go-version-file` isn't an option

Follow-up from [#330 review](https://github.com/chronosphereio/calyptia-api/pull/330#issuecomment-4596848449).

## Test plan
- [ ] Release workflow still works with Go 1.26.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)