### PR TITLE
ci: Upgrade remaining GitHub Actions to Node 22+ runtimes [sc-178410]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           go-version: "^1.26.3"
 
       - name: Release
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           args: release --clean
         env:


### PR DESCRIPTION
## Summary
- Upgrades remaining JS-based GitHub Actions from Node 20 to Node 22+ versions (second wave)
- SHA-pins all upgraded action references for supply-chain security
- Covers docker/*, google-github-actions/*, aws-actions/*, azure/*, goreleaser/*, helm/kind-action, crazy-max/ghaction-import-gpg, and first-wave stragglers missed by a regex bug
- Addresses upcoming [Node 20 deprecation](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)

[sc-178410](https://app.shortcut.com/chronosphere/story/178410)

## Test plan
- [ ] CI passes on this branch
- [ ] Verify workflow behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)